### PR TITLE
feat: 인증/인가 시스템 구축 (#7)

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -72,6 +72,14 @@ jobs:
                  -e PROD_MYSQL_URL=${{ secrets.PROD_MYSQL_URL }} \
                  -e PROD_MYSQL_USER=${{ secrets.PROD_MYSQL_USER }} \
                  -e PROD_MYSQL_PASSWORD=${{ secrets.PROD_MYSQL_PASSWORD }} \
+                 -e REDIS_HOST=${{ secrets.REDIS_HOST }} \
+                 -e REDIS_PORT=${{ secrets.REDIS_PORT }} \
+                 -e REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }} \
+                 -e JWT_KEY=${{ secrets.JWT_KEY }} \
+                 -e FRONT_ORIGIN=${{ secrets.FRONT_ORIGIN }} \
+                 -e KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} \
+                 -e KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }} \
+                 -e KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }} \
                  ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
 
             sudo docker system prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21
+FROM eclipse-temurin:21-jre
 
 ARG JAR_FILE=build/libs/*.jar
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// jwt token
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/idear/backend/auth/application/service/AuthService.java
+++ b/src/main/java/com/idear/backend/auth/application/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.idear.backend.auth.application.service;
+
+import com.idear.backend.auth.infrastructure.repository.RefreshTokenRepository;
+import com.idear.backend.auth.dto.response.TokenResponse;
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.security.token.TokenProvider;
+import com.idear.backend.global.dto.UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.idear.backend.global.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public TokenResponse reissue(String refreshToken) {
+        if (!refreshTokenRepository.existsByRefresh(refreshToken)) {
+            throw CustomException.of(INVALID_REFRESH_TOKEN);
+        }
+
+        UserInfo userInfo = refreshTokenRepository.getUserInfo(refreshToken);
+        if (userInfo == null) {
+            throw CustomException.of(INVALID_REFRESH_TOKEN);
+        }
+
+        refreshTokenRepository.deleteByRefresh(refreshToken);
+
+        String newAccessToken = tokenProvider.generateAccessToken(userInfo);
+        String newRefreshToken = tokenProvider.generateRefreshToken(userInfo);
+
+        return TokenResponse.builder()
+                .access(newAccessToken)
+                .refresh(newRefreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/idear/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/idear/backend/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.idear.backend.auth.controller;
+
+import com.idear.backend.auth.application.service.AuthService;
+import com.idear.backend.auth.dto.request.RefreshTokenRequest;
+import com.idear.backend.auth.dto.response.TokenResponse;
+import com.idear.backend.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@RequestBody RefreshTokenRequest request) {
+        TokenResponse tokenResponse = authService.reissue(request.refresh());
+        ApiResponse<TokenResponse> response = ApiResponse.success(tokenResponse);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/idear/backend/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/idear/backend/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,3 @@
+package com.idear.backend.auth.dto.request;
+
+public record RefreshTokenRequest(String refresh) { }

--- a/src/main/java/com/idear/backend/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/idear/backend/auth/dto/response/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.idear.backend.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(String access, String refresh) { }

--- a/src/main/java/com/idear/backend/auth/infrastructure/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/idear/backend/auth/infrastructure/repository/RefreshTokenRepository.java
@@ -1,0 +1,39 @@
+package com.idear.backend.auth.infrastructure.repository;
+
+import com.idear.backend.global.dto.UserInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+public class RefreshTokenRepository {
+
+    @Value("${secret.jwt.refresh.expiration}")
+    long refreshTokenExpiration;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RefreshTokenRepository(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void saveRefreshToken(String refreshToken, UserInfo userInfo) {
+        redisTemplate.opsForValue().set(refreshToken, userInfo);
+        Duration duration = Duration.ofMillis(refreshTokenExpiration);
+        redisTemplate.expire(refreshToken, duration);
+    }
+
+    public UserInfo getUserInfo(String refreshToken) {
+        return (UserInfo) redisTemplate.opsForValue().get(refreshToken);
+    }
+
+    public boolean existsByRefresh(String refresh) {
+        return redisTemplate.hasKey(refresh);
+    }
+
+    public void deleteByRefresh(String refresh) {
+        redisTemplate.delete(refresh);
+    }
+}

--- a/src/main/java/com/idear/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/idear/backend/global/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package com.idear.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+
+        return template;
+    }
+}

--- a/src/main/java/com/idear/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/idear/backend/global/config/SecurityConfig.java
@@ -1,5 +1,12 @@
 package com.idear.backend.global.config;
 
+import com.idear.backend.global.security.filter.ExceptionHandlerFilter;
+import com.idear.backend.global.security.handler.CustomAccessDeniedHandler;
+import com.idear.backend.global.security.handler.CustomAuthenticationEntryPoint;
+import com.idear.backend.global.security.filter.JwtAuthenticationFilter;
+import com.idear.backend.global.security.oauth.service.CustomOAuth2UserService;
+import com.idear.backend.global.security.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -10,21 +17,32 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
     private final String[] PUBLIC_POST = {
-            "/test/**"
+            "/auth/reissue"
     };
 
     private final String[] PUBLIC_GET = {
             "/",
-            "/test/**"
+            "/test/hello",
+            "/oauth2/authorization/**",
+            "/login/oauth2/code/**"
     };
 
     private final String[] PUBLIC_PUT = {
@@ -37,10 +55,20 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
 
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
                 .sessionManagement(session
                         -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                )
 
                 // 경로별 접근제어
                 .authorizeHttpRequests(auth -> auth
@@ -48,6 +76,15 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, PUBLIC_GET).permitAll()
                         .requestMatchers(HttpMethod.PUT, PUBLIC_PUT).permitAll()
                         .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class)
+
+                // 예외 처리
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/idear/backend/global/dto/UserInfo.java
+++ b/src/main/java/com/idear/backend/global/dto/UserInfo.java
@@ -1,0 +1,7 @@
+package com.idear.backend.global.dto;
+
+import com.idear.backend.user.domain.UserRole;
+import lombok.Builder;
+
+@Builder
+public record UserInfo(Long id, String name, String email, String providerInfo, UserRole role) { }

--- a/src/main/java/com/idear/backend/global/exception/CustomException.java
+++ b/src/main/java/com/idear/backend/global/exception/CustomException.java
@@ -7,13 +7,21 @@ public class CustomException extends RuntimeException {
 
   private final ErrorCode errorCode;
 
-  public CustomException(ErrorCode errorCode) {
+  private CustomException(ErrorCode errorCode) {
     super(errorCode.getMessage());
     this.errorCode = errorCode;
   }
 
-  public CustomException(ErrorCode errorCode, String message) {
+  private CustomException(ErrorCode errorCode, String message) {
     super(message);
     this.errorCode = errorCode;
+  }
+
+  public static CustomException of(ErrorCode errorCode){
+    return new CustomException(errorCode);
+  }
+
+  public static CustomException of(ErrorCode errorCode, String message){
+    return new CustomException(errorCode, message);
   }
 }

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -8,7 +8,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    EXAMPLE_ERROR(HttpStatus.BAD_REQUEST, "C000", "잘못된 요청입니다.");
+    // Global
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 오류가 발생했습니다."),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "A003", "이미 만료된 토큰입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "유효하지 않은 엑세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "유효하지 않은 리프레시 토큰입니다."),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/idear/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/idear/backend/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
-package com.idear.backend.global;
+package com.idear.backend.global.exception;
 
-import com.idear.backend.global.exception.CustomException;
-import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.global.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/idear/backend/global/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/idear/backend/global/security/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,54 @@
+package com.idear.backend.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idear.backend.global.ApiResponse;
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            log.error("CustomException in filter: {}", e.getMessage());
+            setErrorResponse(response, e.getErrorCode());
+        } catch (Exception e) {
+            log.error("Unexpected exception in filter: {}", e.getMessage(), e);
+            setErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        try {
+            ApiResponse<?> errorResponse = ApiResponse.error(errorCode);
+            String json = objectMapper.writeValueAsString(errorResponse);
+            response.getWriter().write(json);
+        } catch (IOException e) {
+            log.error("Error writing error response: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/idear/backend/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package com.idear.backend.global.security.filter;
+
+import com.idear.backend.global.security.token.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String accessToken = tokenProvider.resolveToken(request);
+
+        if (accessToken != null) {
+            Authentication authentication = tokenProvider.validateToken(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/idear/backend/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.idear.backend.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idear.backend.global.ApiResponse;
+import com.idear.backend.global.exception.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements org.springframework.security.web.access.AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        log.error("Access denied: {}", accessDeniedException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse = ApiResponse.error(ErrorCode.ACCESS_DENIED);
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/idear/backend/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.idear.backend.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idear.backend.global.ApiResponse;
+import com.idear.backend.global.exception.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements org.springframework.security.web.AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        log.error("Authentication failed: {}", authException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse = ApiResponse.error(ErrorCode.UNAUTHORIZED);
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/oauth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/idear/backend/global/security/oauth/dto/CustomOAuth2User.java
@@ -1,0 +1,39 @@
+package com.idear.backend.global.security.oauth.dto;
+
+import com.idear.backend.global.dto.UserInfo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Map<String, Object> attributes;
+    private final UserInfo userInfo;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(userInfo.role().toRoleString()));
+    }
+
+    @Override
+    public String getName() {
+        return this.userInfo.name();
+    }
+
+    public static CustomOAuth2User of(Map<String, Object> attributes, UserInfo userInfo) {
+        return new CustomOAuth2User(attributes, userInfo);
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/oauth/dto/KakaoResponse.java
+++ b/src/main/java/com/idear/backend/global/security/oauth/dto/KakaoResponse.java
@@ -1,0 +1,48 @@
+package com.idear.backend.global.security.oauth.dto;
+
+import java.util.Map;
+
+public class KakaoResponse implements OAuth2Response {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+
+    public KakaoResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProviderInfo() {
+        return getProvider()+"_"+getProviderId();
+    }
+
+    @Override
+    public String getEmail() {
+        if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
+            return kakaoAccount.get("email").toString();
+        }
+        return null; // 이메일이 없는 경우 null 반환
+    }
+
+    @Override
+    public String getName() {
+        if (kakaoAccount != null && kakaoAccount.containsKey("profile")) {
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+            if (profile != null && profile.containsKey("nickname")) {
+                return profile.get("nickname").toString();
+            }
+        }
+        return null; // 이름이 없는 경우 null 반환
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/oauth/dto/OAuth2Response.java
+++ b/src/main/java/com/idear/backend/global/security/oauth/dto/OAuth2Response.java
@@ -1,0 +1,17 @@
+package com.idear.backend.global.security.oauth.dto;
+
+public interface OAuth2Response {
+
+    // Provider (kakao, naver 등)
+    String getProvider();
+
+    // Provider 발급 아이디
+    String getProviderId();
+
+    // 서드파티 유일 식별자
+    String getProviderInfo();
+
+    String getEmail();
+
+    String getName();
+}

--- a/src/main/java/com/idear/backend/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/idear/backend/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,37 @@
+package com.idear.backend.global.security.oauth.handler;
+
+import com.idear.backend.global.security.oauth.dto.CustomOAuth2User;
+import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.global.security.token.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Value("${spring.front.origin}")
+    private String frontDomain;
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+        CustomOAuth2User oauth2User = (CustomOAuth2User) authToken.getPrincipal();
+
+        UserInfo userInfo = oauth2User.getUserInfo();
+        String refreshToken = tokenProvider.generateRefreshToken(userInfo);
+
+        response.sendRedirect(frontDomain+"?refresh="+refreshToken);
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/idear/backend/global/security/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,60 @@
+package com.idear.backend.global.security.oauth.service;
+
+import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.global.security.oauth.dto.CustomOAuth2User;
+import com.idear.backend.global.security.oauth.dto.KakaoResponse;
+import com.idear.backend.global.security.oauth.dto.OAuth2Response;
+import com.idear.backend.user.domain.User;
+import com.idear.backend.user.domain.UserRole;
+import com.idear.backend.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        Map<String, Object> attributes = oauth2User.getAttributes();
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // kakao
+
+        OAuth2Response oAuth2Response = null;
+
+        if (provider.equals("kakao")) {
+            oAuth2Response = new KakaoResponse(attributes);
+        }
+        else {
+            return null;
+        }
+
+        String name = oAuth2Response.getName();
+        String email = oAuth2Response.getEmail();
+        String providerInfo = oAuth2Response.getProviderInfo();
+
+        // DB에 유저 없으면 생성
+        User user = userRepository.findByProviderInfo(providerInfo)
+                .orElseGet(() -> userRepository.save(User.of(name, email, providerInfo, UserRole.USER)));
+
+        UserInfo userInfo = UserInfo.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .providerInfo(user.getProviderInfo())
+                .role(user.getRole())
+                .build();
+
+        return CustomOAuth2User.of(attributes, userInfo);
+    }
+}

--- a/src/main/java/com/idear/backend/global/security/token/TokenProvider.java
+++ b/src/main/java/com/idear/backend/global/security/token/TokenProvider.java
@@ -1,0 +1,104 @@
+package com.idear.backend.global.security.token;
+
+import com.idear.backend.auth.infrastructure.repository.RefreshTokenRepository;
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.user.domain.UserRole;
+import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static com.idear.backend.global.exception.ErrorCode.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private static final String BEARER = "Bearer ";
+
+    @Value("${secret.jwt.key}")
+    private String secretKey;
+
+    @Value("${secret.jwt.access.expiration}")
+    private long accessTokenExpiration;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String generateRefreshToken(UserInfo userInfo) {
+        String refreshToken = UUID.randomUUID().toString();
+        refreshTokenRepository.saveRefreshToken(refreshToken, userInfo);
+        return refreshToken;
+    }
+
+    public String generateAccessToken(UserInfo userInfo) {
+        final Claims claims = Jwts.claims();
+        claims.put("sub", String.valueOf(userInfo.id()));
+        claims.put("role", String.valueOf(userInfo.role()));
+
+        Date now = new Date(System.currentTimeMillis());
+        Date expiredAt = new Date(System.currentTimeMillis()+accessTokenExpiration);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiredAt)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader(AUTHORIZATION);
+        if (StringUtils.hasText(authorization) && authorization.startsWith(BEARER)) {
+            return authorization.substring(BEARER.length());
+        }
+        return null;
+    }
+
+    public Authentication validateToken(String accessToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(accessToken);
+            Claims body = claims.getBody();
+
+            return getAuthentication(body);
+        } catch (ExpiredJwtException e) {
+            throw CustomException.of(EXPIRED_TOKEN);
+        } catch (MalformedJwtException e) {
+            throw CustomException.of(INVALID_ACCESS_TOKEN, "잘못된 형식의 토큰입니다");
+        } catch (SignatureException | SecurityException e) {
+            throw CustomException.of(INVALID_ACCESS_TOKEN, "유효하지 않은 서명입니다");
+        } catch (IllegalArgumentException e) {
+            throw CustomException.of(INVALID_ACCESS_TOKEN, "유효하지 않은 토큰입니다");
+        }
+    }
+
+    private Authentication getAuthentication(Claims claims) {
+        String userIdStr = claims.get("sub", String.class);
+        Long userId = Long.parseLong(userIdStr);
+
+        String roleStr = claims.get("role", String.class);
+        UserRole role = UserRole.valueOf(roleStr);
+
+        List<GrantedAuthority> authorities = Collections.singletonList(
+            new SimpleGrantedAuthority(role.toRoleString())
+        );
+
+        UserInfo userInfo = UserInfo.builder()
+            .id(userId)
+            .build();
+
+        return new UsernamePasswordAuthenticationToken(userInfo, null, authorities);
+    }
+}

--- a/src/main/java/com/idear/backend/test/controller/TestController.java
+++ b/src/main/java/com/idear/backend/test/controller/TestController.java
@@ -1,24 +1,30 @@
 package com.idear.backend.test.controller;
 
-import com.idear.backend.global.exception.CustomException;
-import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.user.application.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/test")
+@RequiredArgsConstructor
 public class TestController {
+
+    private final UserService userService;
 
     @GetMapping("/hello")
     public ResponseEntity<?> helloTest() {
         return ResponseEntity.ok("HELLO I-DEAR!");
     }
 
-    @PostMapping("/throw")
-    public ResponseEntity<?> throwTest() {
-        throw new CustomException(ErrorCode.EXAMPLE_ERROR);
+    @GetMapping("/whoami")
+    public ResponseEntity<?> whoAmITest(@AuthenticationPrincipal UserInfo userInfo) {
+        Long userId = userInfo.id();
+        String name = userService.getNameById(userId);
+        return ResponseEntity.ok("YOUR NAME IS: "+name);
     }
 }

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -1,0 +1,21 @@
+package com.idear.backend.user.application.service;
+
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.user.domain.User;
+import com.idear.backend.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public String getNameById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
+        return user.getName();
+    }
+}

--- a/src/main/java/com/idear/backend/user/domain/User.java
+++ b/src/main/java/com/idear/backend/user/domain/User.java
@@ -1,0 +1,46 @@
+package com.idear.backend.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String providerInfo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    private LocalDateTime deletedAt;
+
+    public static User of(String name, String email, String providerInfo, UserRole role){
+        return User.builder()
+                .name(name)
+                .email(email)
+                .providerInfo(providerInfo)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/idear/backend/user/domain/UserRole.java
+++ b/src/main/java/com/idear/backend/user/domain/UserRole.java
@@ -1,0 +1,10 @@
+package com.idear.backend.user.domain;
+
+public enum UserRole {
+    USER,
+    ADMIN;
+
+    public String toRoleString() {
+        return "ROLE_"+this.name();
+    }
+}

--- a/src/main/java/com/idear/backend/user/infrastructure/repository/UserRepository.java
+++ b/src/main/java/com/idear/backend/user/infrastructure/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.idear.backend.user.infrastructure.repository;
+
+import com.idear.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderInfo(String providerInfo);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,29 @@ spring:
       hibernate:
         show-sql: true
 
+  front:
+    origin: ${FRONT_ORIGIN_LOCAL}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            redirect-uri: ${KAKAO_REDIRECT_URI_LOCAL}
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 ---
 spring:
   config:
@@ -67,3 +90,26 @@ spring:
     properties:
       hibernate:
         show-sql: false
+
+  front:
+    origin: ${FRONT_ORIGIN}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,23 @@ spring:
   profiles:
     active: local # 기본 active profile
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
 server:
   servlet:
     context-path: /api
+
+secret:
+  jwt:
+    key: ${JWT_KEY}
+    access:
+      expiration: 3600000
+    refresh:
+      expiration: 1209600000
 
 ---
 spring:

--- a/src/test/java/com/idear/backend/BackendApplicationTests.java
+++ b/src/test/java/com/idear/backend/BackendApplicationTests.java
@@ -1,9 +1,12 @@
 package com.idear.backend;
 
+import com.idear.backend.config.EmbeddedRedisConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(EmbeddedRedisConfig.class)
 class BackendApplicationTests {
 
 	@Test

--- a/src/test/java/com/idear/backend/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/idear/backend/config/EmbeddedRedisConfig.java
@@ -1,0 +1,27 @@
+package com.idear.backend.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.boot.test.context.TestConfiguration;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@TestConfiguration
+public class EmbeddedRedisConfig {
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        redisServer = new RedisServer(6379);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,3 +19,37 @@ spring:
   h2:
     console:
       enabled: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
+  front:
+    origin: http://localhost:3000
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+secret:
+  jwt:
+    key: testjwtsecretkeytestjwtsecretkeytestjwtsecretkeytestjwtsecretkey
+    access:
+      expiration: 3600000
+    refresh:
+      expiration: 1209600000


### PR DESCRIPTION
### 연관된 이슈
> Closes #7 

### 작업 내용
- User 도메인 및 JWT/Redis 기반 인증 인프라 구축
- 카카오 OAuth2 소셜 로그인 연동
- 엑세스 & 리프레시 토큰 기반 인증 시스템 구현
- Spring Security 설정 및 JWT 인증 필터 추가
- 인증 테스트 엔드포인트 추가 (/test/whoami)

### ETC
- 리프레시 토큰 Redis 저장, 재발급 시 갱신
- 현재 카카오만 지원, 추후 다른 서드파티 확장 예정
