### PR TITLE
FEAT: idea 등록 기능 추가(#3)

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,77 +1,77 @@
-name: CD Workflow
-
-on:
-  push:
-    branches:
-      - 'master'
-      - 'develop'
-
-permissions:
-  contents: read
-
-jobs:
-  build-and-push-docker-image:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Grant execute permission to gradlew
-        shell: bash
-        run: chmod +x ./gradlew
-
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.6.0
-        with:
-          arguments: clean bootJar
-
-      - name: docker image build
-        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }} .
-
-      - name: docker login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: docker Hub push
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
-
-  deploy-to-ec2:
-    if: github.event_name == 'push'
-    needs: build-and-push-docker-image
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_KEY }}
-          script: |
-            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
-
-            CONTAINER_ID=$(sudo docker ps -aqf "name=^/idear-api$")
-            if [ -n "$CONTAINER_ID" ]; then
-              echo "Stopping existing container: $CONTAINER_ID"
-              sudo docker stop $CONTAINER_ID
-              sudo docker rm $CONTAINER_ID
-            else
-              echo "No existing container to stop."
-            fi
-
-            echo "Running the new container with image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}"
-            sudo docker run --name idear-api -d -p 8080:8080 \
-                 -e SPRING_PROFILES_ACTIVE=prod \
-                 -e PROD_MYSQL_URL=${{ secrets.PROD_MYSQL_URL }} \
-                 -e PROD_MYSQL_USER=${{ secrets.PROD_MYSQL_USER }} \
-                 -e PROD_MYSQL_PASSWORD=${{ secrets.PROD_MYSQL_PASSWORD }} \
-                 ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
-
-            sudo docker system prune -f
+#name: CD Workflow
+#
+#on:
+#  push:
+#    branches:
+#      - 'master'
+#      - 'develop'
+#
+#permissions:
+#  contents: read
+#
+#jobs:
+#  build-and-push-docker-image:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Set up JDK 21
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '21'
+#          distribution: 'temurin'
+#
+#      - name: Grant execute permission to gradlew
+#        shell: bash
+#        run: chmod +x ./gradlew
+#
+#      - name: Build with Gradle
+#        uses: gradle/gradle-build-action@v2.6.0
+#        with:
+#          arguments: clean bootJar
+#
+#      - name: docker image build
+#        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }} .
+#
+#      - name: docker login
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+#
+#      - name: docker Hub push
+#        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
+#
+#  deploy-to-ec2:
+#    if: github.event_name == 'push'
+#    needs: build-and-push-docker-image
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Deploy to EC2
+#        uses: appleboy/ssh-action@master
+#        with:
+#          host: ${{ secrets.EC2_HOST }}
+#          username: ${{ secrets.EC2_USERNAME }}
+#          key: ${{ secrets.EC2_KEY }}
+#          script: |
+#            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
+#
+#            CONTAINER_ID=$(sudo docker ps -aqf "name=^/idear-api$")
+#            if [ -n "$CONTAINER_ID" ]; then
+#              echo "Stopping existing container: $CONTAINER_ID"
+#              sudo docker stop $CONTAINER_ID
+#              sudo docker rm $CONTAINER_ID
+#            else
+#              echo "No existing container to stop."
+#            fi
+#
+#            echo "Running the new container with image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}"
+#            sudo docker run --name idear-api -d -p 8080:8080 \
+#                 -e SPRING_PROFILES_ACTIVE=prod \
+#                 -e PROD_MYSQL_URL=${{ secrets.PROD_MYSQL_URL }} \
+#                 -e PROD_MYSQL_USER=${{ secrets.PROD_MYSQL_USER }} \
+#                 -e PROD_MYSQL_PASSWORD=${{ secrets.PROD_MYSQL_PASSWORD }} \
+#                 ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
+#
+#            sudo docker system prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ out/
 .vscode/
 
 ### env ###
+.env
 application-local.yml
 application-prod.yml

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/idear/backend/global/ApiResponse.java
+++ b/src/main/java/com/idear/backend/global/ApiResponse.java
@@ -22,6 +22,9 @@ public class ApiResponse<T> {
     }
 
     // SUCCESS
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(STATUS_SUCCESS, "200", "OK", null);
+    }
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(STATUS_SUCCESS, "200", "OK", data);
     }
@@ -39,4 +42,5 @@ public class ApiResponse<T> {
                 null
         );
     }
+
 }

--- a/src/main/java/com/idear/backend/global/config/S3Config.java
+++ b/src/main/java/com/idear/backend/global/config/S3Config.java
@@ -21,11 +21,14 @@ public class S3Config {
 	@Value("${cloud.aws.credentials.secret-key}")
 	private String secretKey;
 
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
 	@Bean
 	public AmazonS3 amazonS3() {
 		return AmazonS3ClientBuilder.standard()
 			.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
-			.withRegion(Regions.AP_NORTHEAST_2)
+			.withRegion(region)
 			.build();
 	}
 }

--- a/src/main/java/com/idear/backend/global/config/S3Config.java
+++ b/src/main/java/com/idear/backend/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.idear.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import lombok.Getter;
+
+@Getter
+@Configuration
+public class S3Config {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		return AmazonS3ClientBuilder.standard()
+			.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+			.withRegion(Regions.AP_NORTHEAST_2)
+			.build();
+	}
+}

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -2,13 +2,20 @@ package com.idear.backend.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    EXAMPLE_ERROR(HttpStatus.BAD_REQUEST, "C000", "잘못된 요청입니다.");
+    EXAMPLE_ERROR(HttpStatus.BAD_REQUEST, "C000", "잘못된 요청입니다."),
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드를 실패했습니다."), 
+    FILE_NOTFOUND_ERROR(HttpStatus.NOT_FOUND, "F002", "존재하지 않는 파일입니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 삭제를 실패했습니다.")
+    ;
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/idear/backend/idea/application/FileStorageService.java
+++ b/src/main/java/com/idear/backend/idea/application/FileStorageService.java
@@ -5,6 +5,6 @@ import java.io.IOException;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface FileStorageService {
-	String uploadFile(MultipartFile file, String uploadDir) throws IOException;
-	void deleteFile(String storedFileName, String uploadDir);
+	String uploadFile(MultipartFile file, String fileName, String uploadDir) throws IOException;
+	void deleteFile(String fileName, String uploadDir) ;
 }

--- a/src/main/java/com/idear/backend/idea/application/FileStorageService.java
+++ b/src/main/java/com/idear/backend/idea/application/FileStorageService.java
@@ -1,0 +1,10 @@
+package com.idear.backend.idea.application;
+
+import java.io.IOException;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+	String uploadFile(MultipartFile file, String uploadDir) throws IOException;
+	void deleteFile(String storedFileName, String uploadDir);
+}

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -12,7 +12,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.idear.backend.idea.domain.Idea;
 import com.idear.backend.idea.domain.IdeaFile;
 import com.idear.backend.idea.dto.request.IdeaRegisterRequest;
-import com.idear.backend.idea.infrastructure.repository.IdeaFileRepository;
 import com.idear.backend.idea.infrastructure.repository.IdeaRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -22,24 +21,20 @@ import lombok.RequiredArgsConstructor;
 public class IdeaService {
 
 	private final IdeaRepository ideaRepository;
-	private final IdeaFileRepository ideaFileRepository;
 	private final FileStorageService fileStorageService;
 
 	@Transactional
 	public void registerIdea(IdeaRegisterRequest ideaRegisterRequest, List<MultipartFile> files) throws IOException {
 		Idea idea = Idea.registerIdea(
-			ideaRegisterRequest.getTitle(), ideaRegisterRequest.getShortDescription(), ideaRegisterRequest.getShortDescription()
+			ideaRegisterRequest.getTitle(), ideaRegisterRequest.getShortDescription(), ideaRegisterRequest.getDescription()
 		);
 		ideaRepository.save(idea);
 
 		List<IdeaFile> ideaFiles = new ArrayList<>();
 		if (files != null && !files.isEmpty()) {
-			for(MultipartFile i:files)
-				System.out.println(i.getOriginalFilename());
-
 			for (MultipartFile file : files) {
 				if (!file.isEmpty()) {
-					String fileName = String.valueOf(UUID.nameUUIDFromBytes(file.getName().getBytes()));
+					String fileName = UUID.randomUUID().toString();
 					String dir = parseExtension(file);
 					IdeaFile.FileType fileType = dir.equals("image") ? IdeaFile.FileType.IMAGE : IdeaFile.FileType.FILE;
 					String url = fileStorageService.uploadFile(file, fileName, dir);
@@ -51,7 +46,6 @@ public class IdeaService {
 
 		if(!ideaFiles.isEmpty()){
 			idea.addFile(ideaFiles);
-			ideaRepository.save(idea);
 		}
 
 		//TODO blockchain 등록, hash 저장, 완료 후 status 변경

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -1,0 +1,77 @@
+package com.idear.backend.idea.application;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.idear.backend.idea.domain.Idea;
+import com.idear.backend.idea.domain.IdeaFile;
+import com.idear.backend.idea.dto.request.IdeaRegisterRequest;
+import com.idear.backend.idea.infrastructure.repository.IdeaFileRepository;
+import com.idear.backend.idea.infrastructure.repository.IdeaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IdeaService {
+
+	private final IdeaRepository ideaRepository;
+	private final IdeaFileRepository ideaFileRepository;
+	private final FileStorageService fileStorageService;
+
+	@Transactional
+	public void registerIdea(IdeaRegisterRequest ideaRegisterRequest, List<MultipartFile> files) throws IOException {
+		Idea idea = Idea.registerIdea(
+			ideaRegisterRequest.getTitle(), ideaRegisterRequest.getShortDescription(), ideaRegisterRequest.getShortDescription()
+		);
+		ideaRepository.save(idea);
+
+		List<IdeaFile> ideaFiles = new ArrayList<>();
+		if (files != null && !files.isEmpty()) {
+			for(MultipartFile i:files)
+				System.out.println(i.getOriginalFilename());
+
+			for (MultipartFile file : files) {
+				if (!file.isEmpty()) {
+					String fileName = String.valueOf(UUID.nameUUIDFromBytes(file.getName().getBytes()));
+					String dir = parseExtension(file);
+					IdeaFile.FileType fileType = dir.equals("image") ? IdeaFile.FileType.IMAGE : IdeaFile.FileType.FILE;
+					String url = fileStorageService.uploadFile(file, fileName, dir);
+					IdeaFile ideaFile = IdeaFile.registerIdeaFile(idea, fileName, url, fileType);
+					ideaFiles.add(ideaFile);
+				}
+			}
+		}
+
+		if(!ideaFiles.isEmpty()){
+			idea.addFile(ideaFiles);
+			ideaRepository.save(idea);
+		}
+
+		//TODO blockchain 등록, hash 저장, 완료 후 status 변경
+		// blockchain.prove();
+	}
+
+
+	private String parseExtension(MultipartFile file) {
+		List<String> imageExtensions = List.of("jpg", "jpeg", "png", "gif", "bmp", "webp", "heic");
+
+		String originalFilename = file.getOriginalFilename();
+		String fileExtension = "";
+		if (originalFilename != null && originalFilename.contains(".")) {
+			fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+		}
+
+		boolean isImage = imageExtensions.contains(fileExtension);
+
+		String resolvedUploadDir = isImage ? "image" : "file";
+
+		return resolvedUploadDir;
+	}
+}

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.idear.backend.global.ApiResponse;
-import com.idear.backend.idea.application.FileStorageService;
 import com.idear.backend.idea.application.IdeaService;
 import com.idear.backend.idea.dto.request.IdeaRegisterRequest;
 

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -1,0 +1,39 @@
+package com.idear.backend.idea.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.idear.backend.global.ApiResponse;
+import com.idear.backend.idea.application.FileStorageService;
+import com.idear.backend.idea.application.IdeaService;
+import com.idear.backend.idea.dto.request.IdeaRegisterRequest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/idea")
+@RequiredArgsConstructor
+public class IdeaController {
+
+	private final IdeaService ideaService;
+
+	/**
+	 * POST /api/idea : 아이디어 등록
+	 */
+	@PostMapping(consumes = {"multipart/form-data"})
+	public ResponseEntity<ApiResponse<Void>> registerIdea(
+		@Valid @RequestPart(value = "request") IdeaRegisterRequest ideaRegisterRequest,
+		@RequestPart(value = "files", required = false) List<MultipartFile> files
+	) throws IOException {
+		ideaService.registerIdea(ideaRegisterRequest, files);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+}

--- a/src/main/java/com/idear/backend/idea/domain/Idea.java
+++ b/src/main/java/com/idear/backend/idea/domain/Idea.java
@@ -1,0 +1,64 @@
+package com.idear.backend.idea.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Idea {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long ideaId;
+
+	//TODO 도메인 연관관계 설정
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "member_id", nullable = false)
+	// private Member member;
+	//
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "contest_id")
+	// private Contest contest;
+
+	@Column(nullable = false, length = 100)
+	private String title;
+
+	@Column(length = 255)
+	private String shortDescription;
+
+	@Lob
+	private String description;
+
+	@OneToMany(mappedBy = "idea", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<IdeaFile> images = new ArrayList<>();
+
+	@Column(length = 64)
+	private String proofHash;
+
+	@Enumerated(EnumType.STRING)
+	private IdeaStatus status;
+
+	private LocalDateTime createdAt;
+
+	public enum IdeaStatus {
+		REGISTERED,
+		PROVING,
+		COMPLETED,
+		WITHDRAWN
+	}
+}

--- a/src/main/java/com/idear/backend/idea/domain/Idea.java
+++ b/src/main/java/com/idear/backend/idea/domain/Idea.java
@@ -45,7 +45,7 @@ public class Idea {
 	private String description;
 
 	@OneToMany(mappedBy = "idea", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<IdeaFile> images = new ArrayList<>();
+	private List<IdeaFile> files = new ArrayList<>();
 
 	@Column(length = 64)
 	private String proofHash;
@@ -56,9 +56,24 @@ public class Idea {
 	private LocalDateTime createdAt;
 
 	public enum IdeaStatus {
-		REGISTERED,
 		PROVING,
 		COMPLETED,
 		WITHDRAWN
+	}
+
+	private Idea(String title, String shortDescription, String description, IdeaStatus status, LocalDateTime createdAt) {
+		this.title = title;
+		this.shortDescription = shortDescription;
+		this.description = description;
+		this.status = status;
+		this.createdAt = createdAt;
+	}
+
+	public static Idea registerIdea(String title, String shortDescription, String description){
+		return new Idea(title, shortDescription, description, IdeaStatus.PROVING, LocalDateTime.now());
+	}
+
+	public void addFile(List<IdeaFile> files){
+		this.files.addAll(files);
 	}
 }

--- a/src/main/java/com/idear/backend/idea/domain/IdeaFile.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaFile.java
@@ -1,0 +1,43 @@
+package com.idear.backend.idea.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class IdeaFile {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long fileId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "idea_id", nullable = false)
+	private Idea idea;
+
+	@Column(nullable = false)
+	private String fileName;
+
+	@Column(nullable = false)
+	private String filePath;
+
+	@Enumerated(EnumType.STRING)
+	private FileType fileType;
+
+	public enum FileType {
+		IMAGE,
+		ATTACHMENT
+	}
+}

--- a/src/main/java/com/idear/backend/idea/domain/IdeaFile.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaFile.java
@@ -38,6 +38,17 @@ public class IdeaFile {
 
 	public enum FileType {
 		IMAGE,
-		ATTACHMENT
+		FILE
+	}
+
+	private IdeaFile(Idea idea, String fileName, String filePath, FileType fileType) {
+		this.idea = idea;
+		this.fileName = fileName;
+		this.filePath = filePath;
+		this.fileType = fileType;
+	}
+
+	public static IdeaFile registerIdeaFile(Idea idea, String fileName, String filePath, FileType fileType) {
+		return new IdeaFile(idea, fileName, filePath, fileType);
 	}
 }

--- a/src/main/java/com/idear/backend/idea/dto/request/IdeaRegisterRequest.java
+++ b/src/main/java/com/idear/backend/idea/dto/request/IdeaRegisterRequest.java
@@ -1,0 +1,18 @@
+package com.idear.backend.idea.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class IdeaRegisterRequest {
+	@NotNull
+	private Long userId;
+	@NotNull
+	private Long contestId;
+	@NotNull
+	private String title;
+	@NotNull
+	private String shortDescription;
+	@NotNull
+	private String description;
+}

--- a/src/main/java/com/idear/backend/idea/infrastructure/external/S3FileStorageService.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/external/S3FileStorageService.java
@@ -2,6 +2,7 @@ package com.idear.backend.idea.infrastructure.external;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,7 +19,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class S3FileStorageService implements FileStorageService {
 
-	private static final String S3_BUCKET_NAME = "idear-file";
+	@Value("${cloud.aws.bucket}")
+	private String bucketName;
 	private final AmazonS3 amazonS3;
 
 	@Override
@@ -31,29 +33,27 @@ public class S3FileStorageService implements FileStorageService {
 
 		try {
 			PutObjectRequest putObjectRequest =
-				new PutObjectRequest(S3_BUCKET_NAME, key, file.getInputStream(), objectMetadata);
+				new PutObjectRequest(bucketName, key, file.getInputStream(), objectMetadata);
 			amazonS3.putObject(putObjectRequest);
 		} catch (IOException e) {
 			throw CustomException.of(ErrorCode.FILE_UPLOAD_ERROR);
 		}
 
-		String accessUrl = amazonS3.getUrl(S3_BUCKET_NAME, key).toString();
+		String accessUrl = amazonS3.getUrl(bucketName, key).toString();
 
 		return accessUrl;
 	}
 
 	@Override
 	public void deleteFile(String storedFileName, String uploadDir) {
-		String key = uploadDir + storedFileName;
+		String key = uploadDir + "/" + storedFileName;
 		try {
-			boolean isObjectExist = amazonS3.doesObjectExist(S3_BUCKET_NAME, key);
+			boolean isObjectExist = amazonS3.doesObjectExist(bucketName, key);
 			if (!isObjectExist){
 				throw CustomException.of(ErrorCode.FILE_NOTFOUND_ERROR);
 			}
-			amazonS3.deleteObject(S3_BUCKET_NAME, key);
+			amazonS3.deleteObject(bucketName, key);
 
-		} catch (CustomException e){
-			throw e;
 		} catch (Exception e) {
 			throw CustomException.of(ErrorCode.FILE_DELETE_ERROR);
 		}

--- a/src/main/java/com/idear/backend/idea/infrastructure/external/S3FileStorageService.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/external/S3FileStorageService.java
@@ -1,0 +1,62 @@
+package com.idear.backend.idea.infrastructure.external;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.idea.application.FileStorageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3FileStorageService implements FileStorageService {
+
+	private static final String S3_BUCKET_NAME = "idear-file";
+	private final AmazonS3 amazonS3;
+
+	@Override
+	public String uploadFile(MultipartFile file, String uploadDir){
+		String storedFileName = file.getOriginalFilename();
+		String key = uploadDir + "/" + storedFileName;
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentType(file.getContentType());
+		objectMetadata.setContentLength(file.getSize());
+
+		try {
+			PutObjectRequest putObjectRequest =
+				new PutObjectRequest(S3_BUCKET_NAME, key, file.getInputStream(), objectMetadata);
+			amazonS3.putObject(putObjectRequest);
+		} catch (IOException e) {
+			throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+
+		String accessUrl = amazonS3.getUrl(S3_BUCKET_NAME, key).toString();
+
+		return accessUrl;
+	}
+
+	@Override
+	public void deleteFile(String storedFileName, String uploadDir) {
+		String key = uploadDir + storedFileName;
+		try {
+			boolean isObjectExist = amazonS3.doesObjectExist(S3_BUCKET_NAME, key);
+			if (!isObjectExist){
+				throw new CustomException(ErrorCode.FILE_NOTFOUND_ERROR);
+			}
+			amazonS3.deleteObject(storedFileName, key);
+
+		} catch (CustomException e){
+			throw e;
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.FILE_DELETE_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/idear/backend/idea/infrastructure/external/S3FileStorageService.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/external/S3FileStorageService.java
@@ -22,9 +22,8 @@ public class S3FileStorageService implements FileStorageService {
 	private final AmazonS3 amazonS3;
 
 	@Override
-	public String uploadFile(MultipartFile file, String uploadDir){
-		String storedFileName = file.getOriginalFilename();
-		String key = uploadDir + "/" + storedFileName;
+	public String uploadFile(MultipartFile file, String fileName, String uploadDir){
+		String key = uploadDir + "/" + fileName;
 
 		ObjectMetadata objectMetadata = new ObjectMetadata();
 		objectMetadata.setContentType(file.getContentType());
@@ -51,7 +50,7 @@ public class S3FileStorageService implements FileStorageService {
 			if (!isObjectExist){
 				throw new CustomException(ErrorCode.FILE_NOTFOUND_ERROR);
 			}
-			amazonS3.deleteObject(storedFileName, key);
+			amazonS3.deleteObject(S3_BUCKET_NAME, key);
 
 		} catch (CustomException e){
 			throw e;

--- a/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaFileRepository.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaFileRepository.java
@@ -1,0 +1,8 @@
+package com.idear.backend.idea.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.idear.backend.idea.domain.IdeaFile;
+
+public interface IdeaFileRepository extends JpaRepository<IdeaFile, Long> {
+}

--- a/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaRepository.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaRepository.java
@@ -1,0 +1,8 @@
+package com.idear.backend.idea.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.idear.backend.idea.domain.Idea;
+
+public interface IdeaRepository extends JpaRepository<Idea, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,9 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+    bucket: idear-file
+    region:
+      static: ap-northeast-2
 
 secret:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,20 @@ spring:
     name: idear-api
   profiles:
     active: local # 기본 active profile
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
 
 server:
   servlet:
     context-path: /api
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,29 @@ spring:
       hibernate:
         show-sql: true
 
+  front:
+    origin: ${FRONT_ORIGIN_LOCAL}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            redirect-uri: ${KAKAO_REDIRECT_URI_LOCAL}
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 ---
 spring:
   config:
@@ -77,3 +100,26 @@ spring:
     properties:
       hibernate:
         show-sql: false
+
+  front:
+    origin: ${FRONT_ORIGIN}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -58,4 +58,7 @@ cloud:
   aws:
     credentials:
       access-key: test
-      secret-key: estt
+      secret-key: tes
+    bucket: idear-file
+    region:
+      static: ap-northeast-2

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -53,3 +53,9 @@ secret:
       expiration: 3600000
     refresh:
       expiration: 1209600000
+
+cloud:
+  aws:
+    credentials:
+      access-key: test
+      secret-key: estt


### PR DESCRIPTION
### 연관된 이슈
#3

### 작업 내용
* 아이디어 등록하여 DB에 저장 기능
* 관련 파일(이미지 최대 4장, 파일 최대 1장) AWS S3에 업로드 기능

### 리뷰 요구사항(선택)


### ETC
* 아이디어 삭제: 블록체인 등록 이후 삭제 안되는데 기능 필요한지 상의 필요
* 아이디어 조회: 유저별 아이디어 조회는 user 도메인 연결 이후 추가, 공모전별 아이디어 조회 기능 필요한지 확인 필요
* User, Contest 도메인 구현 완료 후 연결 필요
* 블록체인 업로드 부분은 구현 완료 후 연동 필요
