### PR TITLE
feat: User 도메인 관련 로직 구현 (#16)

### DIFF
--- a/src/main/java/com/idear/backend/auth/application/service/AuthService.java
+++ b/src/main/java/com/idear/backend/auth/application/service/AuthService.java
@@ -34,9 +34,6 @@ public class AuthService {
         String newAccessToken = tokenProvider.generateAccessToken(userInfo);
         String newRefreshToken = tokenProvider.generateRefreshToken(userInfo);
 
-        return TokenResponse.builder()
-                .access(newAccessToken)
-                .refresh(newRefreshToken)
-                .build();
+        return TokenResponse.of(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/idear/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/idear/backend/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.idear.backend.auth.application.service.AuthService;
 import com.idear.backend.auth.dto.request.RefreshTokenRequest;
 import com.idear.backend.auth.dto.response.TokenResponse;
 import com.idear.backend.global.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,8 +20,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/reissue")
-    public ResponseEntity<?> reissue(@RequestBody RefreshTokenRequest request) {
-        TokenResponse tokenResponse = authService.reissue(request.refresh());
+    public ResponseEntity<?> reissue(@Valid @RequestBody RefreshTokenRequest request) {
+        TokenResponse tokenResponse = authService.reissue(request.getRefresh());
         ApiResponse<TokenResponse> response = ApiResponse.success(tokenResponse);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/idear/backend/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/idear/backend/auth/dto/request/RefreshTokenRequest.java
@@ -1,3 +1,10 @@
 package com.idear.backend.auth.dto.request;
 
-public record RefreshTokenRequest(String refresh) { }
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequest {
+	@NotBlank(message = "리프레시 토큰 문자열은 필수입니다.")
+	private String refresh;
+}

--- a/src/main/java/com/idear/backend/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/idear/backend/auth/dto/response/TokenResponse.java
@@ -1,6 +1,18 @@
 package com.idear.backend.auth.dto.response;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
-public record TokenResponse(String access, String refresh) { }
+public class TokenResponse {
+	private String access;
+	private String refresh;
+
+    public static TokenResponse of(String access, String refresh) {
+        return TokenResponse.builder()
+                .access(access)
+                .refresh(refresh)
+                .build();
+    }
+}

--- a/src/main/java/com/idear/backend/global/ApiResponse.java
+++ b/src/main/java/com/idear/backend/global/ApiResponse.java
@@ -43,4 +43,12 @@ public class ApiResponse<T> {
         );
     }
 
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, T data) {
+        return new ApiResponse<>(
+                STATUS_ERROR,
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                data
+        );
+    }
 }

--- a/src/main/java/com/idear/backend/global/annotation/ValidatedUser.java
+++ b/src/main/java/com/idear/backend/global/annotation/ValidatedUser.java
@@ -1,0 +1,11 @@
+package com.idear.backend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidatedUser {
+}

--- a/src/main/java/com/idear/backend/global/config/WebConfig.java
+++ b/src/main/java/com/idear/backend/global/config/WebConfig.java
@@ -1,13 +1,19 @@
 package com.idear.backend.global.config;
 
+import com.idear.backend.global.resolver.ValidatedUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final ValidatedUserArgumentResolver validatedUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -17,5 +23,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .exposedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(validatedUserArgumentResolver);
     }
 }

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "유효하지 않은 리프레시 토큰입니다."),
 
     // User
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저입니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저입니다."),
+    USER_DELETED(HttpStatus.NOT_FOUND, "U002", "탈퇴 처리된 유저입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
     // Global
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "G002", "유효하지 않은 입력입니다."),
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),

--- a/src/main/java/com/idear/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/idear/backend/global/exception/GlobalExceptionHandler.java
@@ -4,10 +4,16 @@ import com.idear.backend.global.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -34,5 +40,23 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         log.error("handleHttpRequestMethodNotSupportedException", e);
         return new ResponseEntity<>(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    // Validation 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        Map<String, String> errors = extractValidationErrors(e.getBindingResult());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT, errors));
+    }
+
+    private Map<String, String> extractValidationErrors(BindingResult bindingResult) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        return errors;
     }
 }

--- a/src/main/java/com/idear/backend/global/resolver/ValidatedUserArgumentResolver.java
+++ b/src/main/java/com/idear/backend/global/resolver/ValidatedUserArgumentResolver.java
@@ -1,0 +1,56 @@
+package com.idear.backend.global.resolver;
+
+import com.idear.backend.global.annotation.ValidatedUser;
+import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.user.domain.User;
+import com.idear.backend.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class ValidatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ValidatedUser.class)
+                && User.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw CustomException.of(ErrorCode.UNAUTHORIZED);
+        }
+
+        UserInfo userInfo = (UserInfo) authentication.getPrincipal();
+        Long userId = userInfo.id();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getDeletedAt() != null) {
+            throw CustomException.of(ErrorCode.USER_DELETED);
+        }
+
+        return user;
+    }
+}

--- a/src/main/java/com/idear/backend/test/controller/TestController.java
+++ b/src/main/java/com/idear/backend/test/controller/TestController.java
@@ -1,10 +1,10 @@
 package com.idear.backend.test.controller;
 
-import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.global.annotation.ValidatedUser;
 import com.idear.backend.user.application.service.UserService;
+import com.idear.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,12 +19,5 @@ public class TestController {
     @GetMapping("/hello")
     public ResponseEntity<?> helloTest() {
         return ResponseEntity.ok("HELLO I-DEAR!");
-    }
-
-    @GetMapping("/whoami")
-    public ResponseEntity<?> whoAmITest(@AuthenticationPrincipal UserInfo userInfo) {
-        Long userId = userInfo.id();
-        String name = userService.getNameById(userId);
-        return ResponseEntity.ok("YOUR NAME IS: "+name);
     }
 }

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -3,7 +3,10 @@ package com.idear.backend.user.application.service;
 import com.idear.backend.global.exception.CustomException;
 import com.idear.backend.global.exception.ErrorCode;
 import com.idear.backend.user.domain.User;
+import com.idear.backend.user.dto.response.UserInfoResponse;
 import com.idear.backend.user.infrastructure.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,9 +16,45 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     public String getNameById(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
+
         return user.getName();
+    }
+
+    @Transactional
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
+
+        return UserInfoResponse.from(user);
+    }
+
+    @Transactional
+    public void updateName(
+            Long userId,
+            @NotBlank(message = "이름은 필수입니다.") String name) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
+
+        user.updateUsername(name);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
+
+        user.deleteUser();
     }
 }

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -1,60 +1,27 @@
 package com.idear.backend.user.application.service;
 
-import com.idear.backend.global.exception.CustomException;
-import com.idear.backend.global.exception.ErrorCode;
 import com.idear.backend.user.domain.User;
 import com.idear.backend.user.dto.response.UserInfoResponse;
-import com.idear.backend.user.infrastructure.repository.UserRepository;
-import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
-
-    @Transactional
-    public String getNameById(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
-
-        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
-
-        return user.getName();
-    }
-
-    @Transactional
-    public UserInfoResponse getUserInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
-
-        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
-
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(User user) {
         return UserInfoResponse.from(user);
     }
 
     @Transactional
-    public void updateName(
-            Long userId,
-            @NotBlank(message = "이름은 필수입니다.") String name) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
-
-        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
-
+    public void updateName(User user, String name) {
         user.updateUsername(name);
     }
 
     @Transactional
-    public void deleteUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.USER_NOT_FOUND));
-
-        if(user.getDeletedAt() != null) throw CustomException.of(ErrorCode.USER_DELETED);
-
+    public void deleteUser(User user) {
         user.deleteUser();
     }
 }

--- a/src/main/java/com/idear/backend/user/controller/UserController.java
+++ b/src/main/java/com/idear/backend/user/controller/UserController.java
@@ -1,0 +1,45 @@
+package com.idear.backend.user.controller;
+
+import com.idear.backend.global.ApiResponse;
+import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.user.application.service.UserService;
+import com.idear.backend.user.dto.request.UpdateNameRequest;
+import com.idear.backend.user.dto.response.UserInfoResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@GetMapping
+	public ResponseEntity<?> getUserInfo(
+		@AuthenticationPrincipal UserInfo userInfo
+	) {
+		UserInfoResponse response = userService.getUserInfo(userInfo.id());
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PatchMapping
+	public ResponseEntity<?> updateName(
+		@AuthenticationPrincipal UserInfo userInfo,
+		@Valid @RequestBody UpdateNameRequest request
+	) {
+		userService.updateName(userInfo.id(), request.getName());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@DeleteMapping
+	public ResponseEntity<?> deleteUser(
+			@AuthenticationPrincipal UserInfo userInfo
+	) {
+		userService.deleteUser(userInfo.id());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+}

--- a/src/main/java/com/idear/backend/user/controller/UserController.java
+++ b/src/main/java/com/idear/backend/user/controller/UserController.java
@@ -1,14 +1,14 @@
 package com.idear.backend.user.controller;
 
 import com.idear.backend.global.ApiResponse;
-import com.idear.backend.global.dto.UserInfo;
+import com.idear.backend.global.annotation.ValidatedUser;
 import com.idear.backend.user.application.service.UserService;
+import com.idear.backend.user.domain.User;
 import com.idear.backend.user.dto.request.UpdateNameRequest;
 import com.idear.backend.user.dto.response.UserInfoResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,26 +20,26 @@ public class UserController {
 
 	@GetMapping
 	public ResponseEntity<?> getUserInfo(
-		@AuthenticationPrincipal UserInfo userInfo
+		@ValidatedUser User user
 	) {
-		UserInfoResponse response = userService.getUserInfo(userInfo.id());
+		UserInfoResponse response = userService.getUserInfo(user);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	@PatchMapping
 	public ResponseEntity<?> updateName(
-		@AuthenticationPrincipal UserInfo userInfo,
+		@ValidatedUser User user,
 		@Valid @RequestBody UpdateNameRequest request
 	) {
-		userService.updateName(userInfo.id(), request.getName());
+		userService.updateName(user, request.getName());
 		return ResponseEntity.ok(ApiResponse.success());
 	}
 
 	@DeleteMapping
 	public ResponseEntity<?> deleteUser(
-			@AuthenticationPrincipal UserInfo userInfo
+		@ValidatedUser User user
 	) {
-		userService.deleteUser(userInfo.id());
+		userService.deleteUser(user);
 		return ResponseEntity.ok(ApiResponse.success());
 	}
 }

--- a/src/main/java/com/idear/backend/user/domain/User.java
+++ b/src/main/java/com/idear/backend/user/domain/User.java
@@ -43,4 +43,16 @@ public class User {
                 .role(role)
                 .build();
     }
+
+    public String getProvider() {
+        return this.providerInfo.split("_")[0];
+    }
+
+    public void updateUsername(String name){
+        this.name = name;
+    }
+
+    public void deleteUser(){
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/idear/backend/user/dto/request/UpdateNameRequest.java
+++ b/src/main/java/com/idear/backend/user/dto/request/UpdateNameRequest.java
@@ -1,0 +1,10 @@
+package com.idear.backend.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateNameRequest {
+	@NotBlank(message = "이름은 필수입니다.")
+	private String name;
+}

--- a/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.idear.backend.user.dto.response;
+
+import com.idear.backend.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+	private String name;
+	private String email;
+	private String provider;
+
+	public static UserInfoResponse from(User user) {
+		return UserInfoResponse.builder()
+				.name(user.getName())
+				.email(user.getEmail())
+				.provider(user.getProvider())
+				.build();
+	}
+}


### PR DESCRIPTION
### 연관된 이슈
> Closes #16 

### 작업 내용
- User 관련 API 구현
- Validation에 대한 ExceptionHandling 설정 추가
- 토큰 갱신 DTO 및 관련 코드 수정
- User 검증 로직을 ArgumentResolver 패턴으로 개선