### PR TITLE
refactor: 크롤링 로직 트랜잭션 외부로 분리 및 서비스 레이어 리팩토링

### DIFF
--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -21,13 +21,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Install Chrome
-        run: |
-          set -ex
-          sudo apt-get update -y
-          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo apt install -y ./google-chrome-stable_current_amd64.deb
-
       - name: Grant execute permission to gradlew
         shell: bash
         run: chmod +x ./gradlew
@@ -38,7 +31,7 @@ jobs:
           arguments: clean bootJar
 
       - name: docker image build
-        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }} .
+        run: docker build -f Dockerfile.api -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }} .
 
       - name: docker login
         uses: docker/login-action@v2

--- a/.github/workflows/cd-crawler-workflow.yml
+++ b/.github/workflows/cd-crawler-workflow.yml
@@ -1,0 +1,94 @@
+name: CD Crawler Workflow
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+    paths:
+      - 'src/main/java/com/idear/backend/contest/crawler/**'
+      - 'src/main/resources/application-crawler.yml'
+      - 'Dockerfile.crawler'
+      - '.github/workflows/cd-crawler-workflow.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push-crawler-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Install Chrome
+        run: |
+          set -ex
+          sudo apt-get update -y
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt install -y ./google-chrome-stable_current_amd64.deb
+
+      - name: Grant execute permission to gradlew
+        shell: bash
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2.6.0
+        with:
+          arguments: clean bootJar
+
+      - name: docker image build (crawler)
+        run: docker build -f Dockerfile.crawler -t ${{ secrets.DOCKERHUB_USERNAME }}/idear-crawler .
+
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: docker Hub push (crawler)
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/idear-crawler
+
+  deploy-crawler-to-ec2:
+    if: github.event_name == 'push'
+    needs: build-and-push-crawler-image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy Crawler to EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_CRAWLER_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            CONTAINER_ID=$(sudo docker ps -aqf "name=^/idear-crawler$")
+            if [ -n "$CONTAINER_ID" ]; then
+              echo "Stopping existing crawler container: $CONTAINER_ID"
+              sudo docker stop $CONTAINER_ID
+              sudo docker rm $CONTAINER_ID
+            else
+              echo "No existing crawler container to stop."
+            fi
+
+            sudo docker rmi -f ${{ secrets.DOCKERHUB_USERNAME }}/idear-crawler || true
+
+            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/idear-crawler
+
+            echo "Running the new crawler container"
+            sudo docker run --name idear-crawler -d \
+                 -e SPRING_PROFILES_ACTIVE=crawler \
+                 -e PROD_MYSQL_URL=${{ secrets.PROD_MYSQL_URL }} \
+                 -e PROD_MYSQL_USER=${{ secrets.PROD_MYSQL_USER }} \
+                 -e PROD_MYSQL_PASSWORD=${{ secrets.PROD_MYSQL_PASSWORD }} \
+                 -e REDIS_HOST=${{ secrets.REDIS_HOST }} \
+                 -e REDIS_PORT=${{ secrets.REDIS_PORT }} \
+                 -e REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }} \
+                 ${{ secrets.DOCKERHUB_USERNAME }}/idear-crawler
+
+            sudo docker system prune -a -f

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21-jre
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -18,4 +18,8 @@ ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# 크롤러 전용 설정 파일 복사
+COPY src/main/resources/application-crawler.yml /app/config/application-crawler.yml
+
+# 크롤러 프로필로 실행
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=crawler", "app.jar"]

--- a/src/main/java/com/idear/backend/contest/crawler/LinkareerCrawlScheduler.java
+++ b/src/main/java/com/idear/backend/contest/crawler/LinkareerCrawlScheduler.java
@@ -29,11 +29,8 @@ public class LinkareerCrawlScheduler {
       return;
     }
 
-    log.info("=== 애플리케이션 시작: 초기 백필 시작 ===");
-
     try {
       linkareerCrawler.initialBackfill();
-      log.info("=== 초기 백필 완료 ===");
     } catch (Exception e) {
       log.error("초기 백필 실패. 다음 스케줄에서 재시도합니다.", e);
     }
@@ -54,11 +51,8 @@ public class LinkareerCrawlScheduler {
       return;
     }
 
-    log.info("=== 스케줄 실행: 일일 업데이트 시작 ===");
-
     try {
       linkareerCrawler.dailyUpdate();
-      log.info("=== 일일 업데이트 완료 ===");
     } catch (Exception e) {
       log.error("일일 업데이트 실패", e);
     }

--- a/src/main/java/com/idear/backend/contest/crawler/LinkareerCrawler.java
+++ b/src/main/java/com/idear/backend/contest/crawler/LinkareerCrawler.java
@@ -1,16 +1,17 @@
 package com.idear.backend.contest.crawler;
 
 import com.idear.backend.contest.crawler.parser.LinkareerPageParser;
+import com.idear.backend.contest.crawler.service.ContestPersistenceService;
 import com.idear.backend.contest.crawler.service.ContestSaveService;
 import com.idear.backend.contest.repository.ContestRepository;
 import com.idear.backend.global.exception.CustomException;
 import com.idear.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -18,24 +19,13 @@ import java.util.Set;
 @ConditionalOnProperty(name = "idear.crawler.enabled", havingValue = "true")
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class LinkareerCrawler {
 
   private final LinkareerPageParser pageParser;
-  private final ContestSaveService saveService;
+  private final ContestSaveService contestSaveService;
   private final ContestRepository contestRepository;
-  private final LinkareerCrawler self;
-
-  public LinkareerCrawler(
-    LinkareerPageParser pageParser,
-    ContestSaveService saveService,
-    ContestRepository contestRepository,
-    @Lazy LinkareerCrawler self
-  ) {
-    this.pageParser = pageParser;
-    this.saveService = saveService;
-    this.contestRepository = contestRepository;
-    this.self = self;
-  }
+  private final ContestPersistenceService contestPersistenceService;
 
   private static final int MAX_PAGES = 3; // 크롤링할 최대 페이지 수 (초기 백필용)
 
@@ -43,11 +33,6 @@ public class LinkareerCrawler {
    * 초기 백필 (최초 1회 실행)
    */
   public void initialBackfill() {
-    if (contestRepository.count() >= 10) {
-      log.info("이미 데이터가 존재하여 초기 백필 스킵");
-      return;
-    }
-
     log.info("=== 초기 백필 시작 ===");
 
     int totalSaved = 0;
@@ -63,7 +48,7 @@ public class LinkareerCrawler {
         }
 
         // 페이지별로 트랜잭션 분리하여 저장
-        int pageSaved = self.processPageBatch(urls, processedUrls);
+        int pageSaved = contestSaveService.saveBatch(urls, processedUrls);
         totalSaved += pageSaved;
 
         // 전체가 중복이면 종료
@@ -84,13 +69,12 @@ public class LinkareerCrawler {
   /**
    * 일일 업데이트
    */
-  @Transactional
   public void dailyUpdate() {
     log.info("=== 일일 업데이트 시작 ===");
 
     try {
       // 1. 마감된 공모전 삭제
-      saveService.deleteClosedContests();
+      contestPersistenceService.deleteClosedContests(LocalDate.now());
 
       // 2. 새 공모전 추가 (페이지 제한 없이, 중복 발견 시 즉시 중단)
       int newCount = crawlNewContests();
@@ -133,7 +117,7 @@ public class LinkareerCrawler {
         }
 
         // 중복이 아니면 상세 크롤링 & 저장
-        if (saveService.saveContestIfNotExists(url, processedUrls)) {
+        if (contestSaveService.saveContestIfNotExists(url, processedUrls)) {
           totalSaved++;
         }
       }
@@ -143,14 +127,6 @@ public class LinkareerCrawler {
 
     log.info("=== 새 공모전 크롤링 완료 (총 {}개 저장) ===", totalSaved);
     return totalSaved;
-  }
-
-  /**
-   * URL 목록 처리
-   */
-  @Transactional
-  public int processPageBatch(List<String> urls, Set<String> processedUrls) {
-    return saveService.saveBatch(urls, processedUrls);
   }
 
   public long countContests() {

--- a/src/main/java/com/idear/backend/contest/crawler/service/ContestBatchSaver.java
+++ b/src/main/java/com/idear/backend/contest/crawler/service/ContestBatchSaver.java
@@ -1,0 +1,65 @@
+package com.idear.backend.contest.crawler.service;
+
+import com.idear.backend.contest.domain.Contest;
+import com.idear.backend.contest.repository.ContestRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Contest 배치 저장 전용 서비스
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ContestBatchSaver {
+
+  private final ContestRepository contestRepository;
+  private final EntityManager entityManager;
+
+  private static final int BATCH_SIZE = 50;
+
+  /**
+   * JDBC Batch Insert를 사용한 배치 저장
+   */
+  @Transactional
+  public void saveAllInBatch(List<Contest> contests) {
+    for (int i = 0; i < contests.size(); i++) {
+      entityManager.persist(contests.get(i));
+
+      // BATCH_SIZE마다 flush & clear
+      if ((i + 1) % BATCH_SIZE == 0) {
+        entityManager.flush();
+        entityManager.clear();
+      }
+    }
+
+    // 남은 데이터 처리
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  /**
+   * 개별 저장 (새 트랜잭션)
+   * 배치 저장 실패 시 폴백용
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public int saveIndividually(List<Contest> contests) {
+    int saved = 0;
+    for (Contest contest : contests) {
+      try {
+        contestRepository.save(contest);
+        saved++;
+        log.info("개별 저장 성공: {}", contest.getTitle());
+      } catch (Exception e) {
+        log.error("개별 저장 실패: {}", contest.getTitle(), e);
+      }
+    }
+    return saved;
+  }
+}

--- a/src/main/java/com/idear/backend/contest/crawler/service/ContestPersistenceService.java
+++ b/src/main/java/com/idear/backend/contest/crawler/service/ContestPersistenceService.java
@@ -11,13 +11,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 
-// ContestPersistenceService.java (새로 생성)
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class ContestPersistenceService {
 
   private final ContestRepository contestRepository;
+  private final ContestBatchSaver batchSaver;
 
   @Transactional
   public boolean saveIfNotDuplicate(Contest contest, String url, Set<String> processedUrls) {
@@ -32,29 +32,24 @@ public class ContestPersistenceService {
     return true;
   }
 
-  @Transactional
+  /**
+   * 배치 저장 with 폴백 로직
+   */
   public int saveBatchWithRetry(List<Contest> contestBatch) {
+    if (contestBatch.isEmpty()) {
+      return 0;
+    }
+
     try {
-      contestRepository.saveAll(contestBatch);
+      // 1차 시도: JDBC Batch Insert
+      batchSaver.saveAllInBatch(contestBatch);
       log.info("배치 저장 완료: {}건", contestBatch.size());
       return contestBatch.size();
     } catch (Exception e) {
       log.error("배치 저장 실패, 개별 저장으로 폴백", e);
-      return saveIndividually(contestBatch);
+      // 2차 시도: 개별 저장 (새 트랜잭션에서 실행)
+      return batchSaver.saveIndividually(contestBatch);
     }
-  }
-
-  private int saveIndividually(List<Contest> contests) {
-    int saved = 0;
-    for (Contest contest : contests) {
-      try {
-        contestRepository.save(contest);
-        saved++;
-      } catch (Exception e) {
-        log.error("개별 저장 실패: {}", contest.getTitle(), e);
-      }
-    }
-    return saved;
   }
 
   @Transactional

--- a/src/main/java/com/idear/backend/contest/crawler/service/ContestPersistenceService.java
+++ b/src/main/java/com/idear/backend/contest/crawler/service/ContestPersistenceService.java
@@ -1,0 +1,69 @@
+package com.idear.backend.contest.crawler.service;
+
+import com.idear.backend.contest.domain.Contest;
+import com.idear.backend.contest.repository.ContestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+// ContestPersistenceService.java (새로 생성)
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ContestPersistenceService {
+
+  private final ContestRepository contestRepository;
+
+  @Transactional
+  public boolean saveIfNotDuplicate(Contest contest, String url, Set<String> processedUrls) {
+    if (isDuplicate(contest)) {
+      processedUrls.add(url);
+      return false;
+    }
+
+    contestRepository.save(contest);
+    processedUrls.add(url);
+    log.info("공모전 저장: {}", contest.getTitle());
+    return true;
+  }
+
+  @Transactional
+  public int saveBatchWithRetry(List<Contest> contestBatch) {
+    try {
+      contestRepository.saveAll(contestBatch);
+      log.info("배치 저장 완료: {}건", contestBatch.size());
+      return contestBatch.size();
+    } catch (Exception e) {
+      log.error("배치 저장 실패, 개별 저장으로 폴백", e);
+      return saveIndividually(contestBatch);
+    }
+  }
+
+  private int saveIndividually(List<Contest> contests) {
+    int saved = 0;
+    for (Contest contest : contests) {
+      try {
+        contestRepository.save(contest);
+        saved++;
+      } catch (Exception e) {
+        log.error("개별 저장 실패: {}", contest.getTitle(), e);
+      }
+    }
+    return saved;
+  }
+
+  @Transactional
+  public int deleteClosedContests(LocalDate date) {
+    return contestRepository.deleteClosedContests(date);
+  }
+
+  public boolean isDuplicate(Contest contest) {
+    String homepageUrl = contest.getHomepageUrl();
+    return homepageUrl != null && contestRepository.existsByHomepageUrl(homepageUrl);
+  }
+}

--- a/src/main/java/com/idear/backend/contest/crawler/service/ContestSaveService.java
+++ b/src/main/java/com/idear/backend/contest/crawler/service/ContestSaveService.java
@@ -2,14 +2,11 @@ package com.idear.backend.contest.crawler.service;
 
 import com.idear.backend.contest.crawler.parser.ContestDetailParser;
 import com.idear.backend.contest.domain.Contest;
-import com.idear.backend.contest.repository.ContestRepository;
 import com.idear.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -19,7 +16,7 @@ import java.util.Set;
 @Service
 public class ContestSaveService {
 
-  private final ContestRepository contestRepository;
+  private final ContestPersistenceService contestPersistenceService;
   private final ContestDetailParser detailParser;
 
   private static final int BATCH_SIZE = 50;
@@ -27,7 +24,6 @@ public class ContestSaveService {
   /**
    * 공모전 저장 (중복 체크 포함)
    */
-  @Transactional
   public boolean saveContestIfNotExists(String linkareerUrl, Set<String> processedUrls) {
     // 메모리 중복 체크
     if (processedUrls.contains(linkareerUrl)) {
@@ -39,18 +35,8 @@ public class ContestSaveService {
       // 상세 정보 크롤링
       Contest contest = detailParser.parseDetailPage(linkareerUrl);
 
-      // DB 중복 체크
-      if (isDuplicate(contest)) {
-        processedUrls.add(linkareerUrl);
-        return false;
-      }
-
       // 저장
-      contestRepository.save(contest);
-      processedUrls.add(linkareerUrl);
-      log.info("공모전 저장: {}", contest.getTitle());
-
-      return true;
+      return contestPersistenceService.saveIfNotDuplicate(contest, linkareerUrl, processedUrls);
 
     } catch (CustomException e) {
       log.error("크롤링 실패: {}", linkareerUrl, e);
@@ -62,7 +48,6 @@ public class ContestSaveService {
   /**
    * 공모전 배치 저장 (여러 건을 한 번에)
    */
-  @Transactional
   public int saveBatch(List<String> urls, Set<String> processedUrls) {
     List<Contest> contestBatch = new ArrayList<>();
     int savedCount = 0;
@@ -78,21 +63,16 @@ public class ContestSaveService {
         // 상세 정보 크롤링
         Contest contest = detailParser.parseDetailPage(url);
 
-        // DB 중복 체크
-        if (!isDuplicate(contest)) {
+        if (!contestPersistenceService.isDuplicate(contest)) {
           contestBatch.add(contest);
-
-          // 배치 크기에 도달하면 저장
-          if (contestBatch.size() >= BATCH_SIZE) {
-            contestRepository.saveAll(contestBatch);
-            savedCount += contestBatch.size();
-            log.info("배치 저장 완료: {}건", contestBatch.size());
-            contestBatch.clear();
-          }
         }
 
         processedUrls.add(url);
 
+        if (contestBatch.size() >= BATCH_SIZE) {
+          savedCount += contestPersistenceService.saveBatchWithRetry(contestBatch);
+          contestBatch.clear();
+        }
       } catch (CustomException e) {
         log.error("크롤링 실패: {}", url, e);
         processedUrls.add(url);
@@ -101,70 +81,9 @@ public class ContestSaveService {
 
     // 남은 데이터 저장
     if (!contestBatch.isEmpty()) {
-      savedCount += saveBatchWithRetry(contestBatch);
+      savedCount += contestPersistenceService.saveBatchWithRetry(contestBatch);
     }
 
     return savedCount;
-  }
-
-  private int saveBatchWithRetry(List<Contest> contestBatch) {
-    try {
-      contestRepository.saveAll(contestBatch);
-      log.info("배치 저장 완료: {}건", contestBatch.size());
-      return contestBatch.size();
-
-    } catch (Exception e) {
-      log.error("배치 저장 실패, 개별 저장으로 폴백: {}건", contestBatch.size(), e);
-      return saveIndividually(contestBatch);
-    }
-  }
-
-  /**
-   * 개별 저장 (폴백 전략)
-   */
-  private int saveIndividually(List<Contest> contests) {
-    int saved = 0;
-
-    for (Contest contest : contests) {
-      try {
-        contestRepository.save(contest);
-        saved++;
-        log.debug("개별 저장 성공: {}", contest.getTitle());
-      } catch (Exception e) {
-        log.error("개별 저장 실패: {} - {}", contest.getTitle(), e.getMessage());
-      }
-    }
-
-    log.info("개별 저장 폴백 완료: {}개 중 {}개 성공", contests.size(), saved);
-    return saved;
-  }
-
-  /**
-   * 마감된 공모전 삭제
-   */
-  @Transactional
-  public int deleteClosedContests() {
-    LocalDate today = LocalDate.now();
-    int deleted = contestRepository.deleteClosedContests(today);
-
-    if (deleted > 0) {
-      log.info("마감된 공모전 {}개 삭제", deleted);
-    }
-
-    return deleted;
-  }
-
-  /**
-   * 중복 체크 (homepageUrl 기준)
-   */
-  private boolean isDuplicate(Contest contest) {
-    String homepageUrl = contest.getHomepageUrl();
-
-    if (homepageUrl != null && contestRepository.existsByHomepageUrl(homepageUrl)) {
-      log.debug("중복된 공모전 (homepageUrl): {}", homepageUrl);
-      return true;
-    }
-
-    return false;
   }
 }

--- a/src/main/resources/application-crawler.yml
+++ b/src/main/resources/application-crawler.yml
@@ -1,0 +1,28 @@
+spring:
+  main:
+    web-application-type: none
+
+  task:
+    scheduling:
+      enabled: true
+
+  datasource:
+    url: ${PROD_MYSQL_URL}
+    username: ${PROD_MYSQL_USER}
+    password: ${PROD_MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  sql:
+    init:
+      mode: never
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show-sql: false
+
+idear:
+  crawler:
+    enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,11 +22,11 @@ spring:
       password: ${REDIS_PASSWORD}
   task:
     scheduling:
-      enabled: true
+      enabled: false
 
 idear:
   crawler:
-    enabled: true
+    enabled: false
 
 server:
   servlet:


### PR DESCRIPTION
### 연관된 이슈

> #6 

### 작업 내용

- `ContestPersistenceService` 추가: 순수 DB 트랜잭션 작업 전담
- `ContestSaveService`: 크롤링과 DB 저장 로직 분리
- `LinkareerCrawler`: `@Transactional` 및 self-injection 패턴 제거
- 중복 로깅 제거
