### PR TITLE
feat: 아이디어 버전 관리 시스템 구현 (#39)

### DIFF
--- a/src/main/java/com/idear/backend/alert/application/service/AlertService.java
+++ b/src/main/java/com/idear/backend/alert/application/service/AlertService.java
@@ -43,8 +43,8 @@ public class AlertService {
     }
 
     @Transactional
-    public void createRegistrationAlert(String content, IdeaFile ideaFile) {
-        Alert alert = Alert.ofRegistration(content, ideaFile);
+    public void createRegistrationAlert(String content, User user, Long ideaId, IdeaFile ideaFile) {
+        Alert alert = Alert.ofRegistration(content, user, ideaId, ideaFile);
         alertRepository.save(alert);
     }
 }

--- a/src/main/java/com/idear/backend/alert/domain/Alert.java
+++ b/src/main/java/com/idear/backend/alert/domain/Alert.java
@@ -46,12 +46,12 @@ public class Alert {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public static Alert ofRegistration(String content, IdeaFile ideaFile){
+    public static Alert ofRegistration(String content, User user, Long ideaId, IdeaFile ideaFile){
         return Alert.builder()
-                .user(ideaFile.getIdea().getUser())
+                .user(user)
                 .alertType(AlertType.REGISTRATION)
                 .content(content)
-                .ideaId(ideaFile.getIdea().getIdeaId())
+                .ideaId(ideaId)
                 .ideaFileId(ideaFile.getIdeaFileId())
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/idear/backend/blockchain/application/BlockchainService.java
+++ b/src/main/java/com/idear/backend/blockchain/application/BlockchainService.java
@@ -5,12 +5,14 @@ import com.idear.backend.blockchain.domain.RegistrationFailureReason;
 import com.idear.backend.blockchain.dto.request.RegistrationResultRequest;
 import com.idear.backend.global.exception.CustomException;
 import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.idea.domain.Idea;
 import com.idear.backend.idea.domain.IdeaFile;
 import com.idear.backend.idea.infrastructure.repository.IdeaFileRepository;
+import com.idear.backend.idea.infrastructure.repository.IdeaRepository;
+import com.idear.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -27,6 +29,7 @@ public class BlockchainService {
 	private String blockchainGatewayUrl;
 
 	private final IdeaFileRepository ideaFileRepository;
+	private final IdeaRepository ideaRepository;
 	private final AlertService alertService;
 	private final RestTemplate restTemplate;
 
@@ -83,8 +86,14 @@ public class BlockchainService {
 
 		ideaFile.registrationSucceed(txHash, registeredAt);
 
+		Idea idea = ideaRepository.findIdeaByFile(ideaFile)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
+		User user = idea.getUser();
+
 		alertService.createRegistrationAlert(
 				"아이디어 파일이 등록되었습니다. 내용이 맞는지 확인해주세요.",
+				user,
+				idea.getIdeaId(),
 				ideaFile
 		);
 
@@ -105,8 +114,14 @@ public class BlockchainService {
 
 		ideaFile.registrationFailed(txHash, reason);
 
+		Idea idea = ideaRepository.findIdeaByFile(ideaFile)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
+		User user = idea.getUser();
+
 		alertService.createRegistrationAlert(
 				"아이디어 파일 등록이 실패하였습니다. 상세 내역을 확인해주세요.",
+				user,
+				idea.getIdeaId(),
 				ideaFile
 		);
 

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     IDEA_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "I002", "존재하지 않는 아이디어 파일입니다."),
     IDEA_FILE_STATUS_MISMATCH(HttpStatus.CONFLICT, "I003", "아이디어 파일의 현재 상태가 요청과 일치하지 않습니다."),
     IDEA_FILE_IDEA_MISMATCH(HttpStatus.NOT_FOUND, "I004", "요청 아이디어에 해당하는 아이디어 파일이 아닙니다."),
+    IDEA_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "I005", "존재하지 않는 아이디어 버전입니다."),
 
     // Crawling
     CRAWLING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "크롤링 중 오류가 발생했습니다."),

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -8,6 +8,7 @@ import com.idear.backend.global.exception.ErrorCode;
 import com.idear.backend.idea.domain.Idea;
 import com.idear.backend.idea.domain.IdeaFile;
 import com.idear.backend.idea.domain.IdeaImage;
+import com.idear.backend.idea.domain.IdeaVersion;
 import com.idear.backend.idea.dto.request.FileSignatureRequest;
 import com.idear.backend.idea.dto.request.IdeaCreateRequest;
 import com.idear.backend.idea.dto.request.SignatureData;
@@ -15,11 +16,11 @@ import com.idear.backend.idea.dto.response.*;
 import com.idear.backend.idea.infrastructure.repository.IdeaFileRepository;
 import com.idear.backend.idea.infrastructure.repository.IdeaImageRepository;
 import com.idear.backend.idea.infrastructure.repository.IdeaRepository;
+import com.idear.backend.idea.infrastructure.repository.IdeaVersionRepository;
 import com.idear.backend.idea.util.HashUtil;
 import com.idear.backend.idea.util.ServerSignatureService;
 import com.idear.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,9 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,6 +36,7 @@ import java.util.stream.Collectors;
 public class IdeaService {
 
 	private final IdeaRepository ideaRepository;
+	private final IdeaVersionRepository ideaVersionRepository;
 	private final IdeaFileRepository ideaFileRepository;
 	private final IdeaImageRepository ideaImageRepository;
 	private final FileStorageService fileStorageService;
@@ -65,14 +65,20 @@ public class IdeaService {
 				user,
 				contest,
 				request.getTitle(),
-				request.getShortDescription(),
-				request.getDescription(),
 				requestedAt
 		);
 		idea = ideaRepository.save(idea);
 
-		processImages(idea, images);
-		List<FileHashInfo> fileHashInfoList = processFiles(idea, files, requestTimestamp);
+		IdeaVersion initialVersion = IdeaVersion.createInitialVersion(
+				request.getShortDescription(),
+				request.getDescription(),
+				requestedAt
+		);
+		idea.addVersion(initialVersion);
+		initialVersion = ideaVersionRepository.save(initialVersion);
+
+		processImages(initialVersion, images);
+		List<FileHashInfo> fileHashInfoList = processFiles(initialVersion, files, requestTimestamp);
 
 		return IdeaRegistrationInitResponse.builder()
 				.ideaId(idea.getIdeaId())
@@ -100,7 +106,10 @@ public class IdeaService {
 			IdeaFile ideaFile = ideaFileRepository.findById(signatureData.getIdeaFileId())
 					.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_FILE_NOT_FOUND));
 
-			if (!ideaFile.getIdea().getIdeaId().equals(ideaId)) {
+			// 현재 Idea의 모든 버전에서 이 파일이 포함되어 있는지 확인
+			boolean fileOwnedByIdea = idea.getVersions().stream()
+					.anyMatch(v -> v.getFiles().contains(ideaFile));
+			if (!fileOwnedByIdea) {
 				throw CustomException.of(ErrorCode.IDEA_FILE_IDEA_MISMATCH);
 			}
 
@@ -146,40 +155,49 @@ public class IdeaService {
 		List<Idea> ideas = ideaRepository.findAllByUser(user);
 
 		return ideas.stream()
-				.map(IdeaSummaryResponse::of)
+				.map(idea -> {
+					IdeaVersion latestVersion = ideaVersionRepository
+							.findLatestByIdea(idea)
+							.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
+					return IdeaSummaryResponse.of(idea, latestVersion);
+				})
 				.collect(Collectors.toList());
 	}
 
 	@Transactional(readOnly = true)
-	public IdeaDetailResponse getIdeaDetail(User user, Long ideaId) {
+	public IdeaWithVersionsResponse getIdeaVersions(User user, Long ideaId) {
 		Idea idea = ideaRepository.findById(ideaId)
-			.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
 
 		if (!idea.getUser().getUserId().equals(user.getUserId())) {
 			throw CustomException.of(ErrorCode.ACCESS_DENIED);
 		}
 
-		return IdeaDetailResponse.of(idea);
+		List<IdeaVersion> versions = ideaVersionRepository.findAllByIdeaOrderByVersionNumberDesc(idea);
+
+		return IdeaWithVersionsResponse.of(idea, versions);
 	}
 
 	@Transactional
 	public void deleteIdea(User user, Long ideaId) {
 		Idea idea = ideaRepository.findById(ideaId)
-			.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
 
 		if (!idea.getUser().getUserId().equals(user.getUserId())) {
 			throw CustomException.of(ErrorCode.ACCESS_DENIED);
 		}
 
-		deleteIdeaFilesFromStorage(idea.getFiles());
-		deleteIdeaImagesFromStorage(idea.getImages());
-
-		ideaFileRepository.deleteAll(idea.getFiles());
-		ideaImageRepository.deleteAll(idea.getImages());
 		ideaRepository.delete(idea);
 	}
 
-	private void processImages(Idea idea, List<MultipartFile> images) throws IOException {
+	private boolean hasNonEmptyFiles(List<MultipartFile> files) {
+		if (files == null || files.isEmpty()) {
+			return false;
+		}
+		return files.stream().anyMatch(file -> file != null && !file.isEmpty());
+	}
+
+	private void processImages(IdeaVersion ideaVersion, List<MultipartFile> images) throws IOException {
 		if (images == null || images.isEmpty()) {
 			return;
 		}
@@ -195,12 +213,13 @@ public class IdeaService {
 						filePath
 				);
 
-				idea.addImage(ideaImage);
+				ideaImage = ideaImageRepository.save(ideaImage);
+				ideaVersion.addImage(ideaImage);
 			}
 		}
 	}
 
-	private List<FileHashInfo> processFiles(Idea idea, List<MultipartFile> files, Long requestTimestamp) throws IOException {
+	private List<FileHashInfo> processFiles(IdeaVersion ideaVersion, List<MultipartFile> files, Long requestTimestamp) throws IOException {
 		List<FileHashInfo> fileHashInfoList = new ArrayList<>();
 
 		if (files == null || files.isEmpty()) {
@@ -226,7 +245,7 @@ public class IdeaService {
 						requestTimestamp
 				);
 
-				idea.addFile(ideaFile);
+				ideaVersion.addFile(ideaFile);
 				ideaFile = ideaFileRepository.save(ideaFile);
 
 				fileHashInfoList.add(FileHashInfo.builder()
@@ -241,15 +260,99 @@ public class IdeaService {
 		return fileHashInfoList;
 	}
 
-	private void deleteIdeaFilesFromStorage(List<IdeaFile> files) {
-		for (IdeaFile file : files) {
-			fileStorageService.deleteFile(file.getFileName(), "file");
-		}
-	}
+	@Transactional
+	public IdeaUpdateResponse updateIdea(
+		User user,
+		Long ideaId,
+		List<Long> deleteFileIds,
+		List<Long> deleteImageIds,
+		String shortDescription,
+		String description,
+		List<MultipartFile> images,
+		List<MultipartFile> files
+	) throws IOException {
+		Idea idea = ideaRepository.findById(ideaId)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
 
-	private void deleteIdeaImagesFromStorage(List<IdeaImage> images) {
-		for (IdeaImage image : images) {
-			fileStorageService.deleteFile(image.getFileName(), "image");
+		if (!idea.getUser().getUserId().equals(user.getUserId())) {
+			throw CustomException.of(ErrorCode.USER_NOT_OWNER);
 		}
+
+		IdeaVersion latestVersion = ideaVersionRepository
+				.findLatestByIdeaWithFilesAndImages(idea)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
+
+		boolean hasFileChanges = (deleteFileIds != null && !deleteFileIds.isEmpty())
+				|| hasNonEmptyFiles(files);
+
+		IdeaVersion targetVersion;
+		List<FileHashInfo> fileHashInfoList = new ArrayList<>();
+		LocalDateTime updatedAt = LocalDateTime.now();
+		Long timestamp = updatedAt.toEpochSecond(ZoneOffset.UTC);
+
+		if (hasFileChanges) {
+			Integer maxVersionNumber = ideaVersionRepository
+				.findMaxVersionNumberByIdea(idea)
+				.orElse(0);
+
+			IdeaVersion newVersion = IdeaVersion.createNewVersion(
+				latestVersion,
+				maxVersionNumber + 1
+			);
+			idea.addVersion(newVersion);
+			newVersion = ideaVersionRepository.save(newVersion);
+
+			// 이미지 참조 복사 (Join Entity)
+			Set<IdeaImage> imagesToKeep = new HashSet<>(latestVersion.getImages());
+			if (deleteImageIds != null && !deleteImageIds.isEmpty()) {
+				imagesToKeep.removeIf(img -> deleteImageIds.contains(img.getIdeaImageId()));
+			}
+			for (IdeaImage image : imagesToKeep) {
+				newVersion.addImage(image);
+			}
+
+			// 파일 참조 복사 (Join Entity)
+			Set<IdeaFile> filesToKeep = new HashSet<>(latestVersion.getFiles());
+			if (deleteFileIds != null && !deleteFileIds.isEmpty()) {
+				filesToKeep.removeIf(file -> deleteFileIds.contains(file.getIdeaFileId()));
+			}
+			for (IdeaFile file : filesToKeep) {
+				newVersion.addFile(file);
+			}
+
+			fileHashInfoList = processFiles(newVersion, files, timestamp);
+
+			if (shortDescription != null || description != null) {
+				newVersion.updateMetadata(
+					shortDescription != null ? shortDescription : newVersion.getShortDescription(),
+					description != null ? description : newVersion.getDescription()
+				);
+			}
+
+			targetVersion = newVersion;
+		} else {
+			if (shortDescription != null || description != null) {
+				latestVersion.updateMetadata(
+					shortDescription != null ? shortDescription : latestVersion.getShortDescription(),
+					description != null ? description : latestVersion.getDescription()
+				);
+			}
+
+			targetVersion = latestVersion;
+		}
+
+		// 메타만 변경 시 이미지 관계 제거
+		if (!hasFileChanges && deleteImageIds != null && !deleteImageIds.isEmpty()) {
+			targetVersion.removeImagesByIds(deleteImageIds);
+		}
+
+		processImages(targetVersion, images);
+
+		return IdeaUpdateResponse.builder()
+			.ideaId(ideaId)
+			.versionNumber(targetVersion.getVersionNumber())
+			.updatedAt(updatedAt)
+			.files(fileHashInfoList)
+			.build();
 	}
 }

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -157,7 +157,7 @@ public class IdeaService {
 		return ideas.stream()
 				.map(idea -> {
 					IdeaVersion latestVersion = ideaVersionRepository
-							.findLatestByIdea(idea)
+							.findTopByIdeaOrderByVersionNumberDesc(idea)
 							.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
 					return IdeaSummaryResponse.of(idea, latestVersion);
 				})

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -5,17 +5,14 @@ import com.idear.backend.global.annotation.ValidatedUser;
 import com.idear.backend.idea.application.IdeaService;
 import com.idear.backend.idea.dto.request.FileSignatureRequest;
 import com.idear.backend.idea.dto.request.IdeaCreateRequest;
-import com.idear.backend.idea.dto.response.IdeaDetailResponse;
-import com.idear.backend.idea.dto.response.IdeaRegistrationCompleteResponse;
-import com.idear.backend.idea.dto.response.IdeaRegistrationInitResponse;
-import com.idear.backend.idea.dto.response.IdeaSummaryResponse;
+import com.idear.backend.idea.dto.request.IdeaUpdateRequest;
+import com.idear.backend.idea.dto.response.*;
 import com.idear.backend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -65,6 +62,34 @@ public class IdeaController {
 	}
 
 	@Operation(
+			summary = "아이디어 수정",
+			description = "아이디어의 파일 및 메타데이터를 수정합니다. 파일 변경 시 새 버전 생성, 메타만 변경 시 최신 버전 수정."
+	)
+	@PatchMapping(value = "/{ideaId}", consumes = {"multipart/form-data"})
+	public ResponseEntity<ApiResponse<IdeaUpdateResponse>> updateIdea(
+			@Parameter(hidden = true) @ValidatedUser User user,
+			@Parameter(description = "아이디어 ID", required = true, example = "1")
+			@PathVariable("ideaId") Long ideaId,
+			@Parameter(description = "수정 정보 (삭제 대상 파일/이미지 ID, 메타데이터)")
+			@RequestPart(value = "ideaData", required = false) IdeaUpdateRequest ideaUpdateRequest,
+			@Parameter(description = "추가할 이미지 목록")
+			@RequestPart(value = "images", required = false) List<MultipartFile> images,
+			@Parameter(description = "추가할 파일 목록")
+			@RequestPart(value = "files", required = false) List<MultipartFile> files
+	) throws IOException {
+		List<Long> deleteFileIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteFileIds() : null;
+		List<Long> deleteImageIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteImageIds() : null;
+		String shortDescription = ideaUpdateRequest != null ? ideaUpdateRequest.getShortDescription() : null;
+		String description = ideaUpdateRequest != null ? ideaUpdateRequest.getDescription() : null;
+
+		IdeaUpdateResponse response = ideaService.updateIdea(
+				user, ideaId, deleteFileIds, deleteImageIds,
+				shortDescription, description, images, files
+		);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@Operation(
 		summary = "내 아이디어 목록 조회",
 		description = "현재 로그인한 사용자가 등록한 모든 아이디어 목록을 조회합니다."
 	)
@@ -78,15 +103,15 @@ public class IdeaController {
 
 	@Operation(
 		summary = "아이디어 상세 조회",
-		description = "특정 아이디어의 상세 정보를 조회합니다. 블록체인 등록 정보 및 첨부 파일 목록을 포함합니다."
+		description = "특정 아이디어의 모든 버전에 대해 최신순으로 조회합니다."
 	)
 	@GetMapping("/{ideaId}")
-	public ResponseEntity<ApiResponse<IdeaDetailResponse>> getIdeaDetail(
+	public ResponseEntity<ApiResponse<IdeaWithVersionsResponse>> getIdea(
 			@Parameter(hidden = true) @ValidatedUser User user,
 			@Parameter(description = "조회할 아이디어 ID", required = true, example = "1")
 			@PathVariable("ideaId") Long ideaId
 	) {
-		IdeaDetailResponse response = ideaService.getIdeaDetail(user, ideaId);
+		IdeaWithVersionsResponse response = ideaService.getIdeaVersions(user, ideaId);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 

--- a/src/main/java/com/idear/backend/idea/domain/Idea.java
+++ b/src/main/java/com/idear/backend/idea/domain/Idea.java
@@ -39,19 +39,9 @@ public class Idea {
 	@Column(nullable = false, length = 100)
 	private String title;
 
-	@Column(length = 255)
-	private String shortDescription;
-
-	@Lob
-	private String description;
-
 	@OneToMany(mappedBy = "idea", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
-	private List<IdeaFile> files = new ArrayList<>();
-
-	@OneToMany(mappedBy = "idea", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<IdeaImage> images = new ArrayList<>();
+	private List<IdeaVersion> versions = new ArrayList<>();
 
 	private LocalDateTime requestedAt;
 
@@ -61,27 +51,18 @@ public class Idea {
 			User user,
 			Contest contest,
 			String title,
-			String shortDescription,
-			String description,
 			LocalDateTime requestedAt
 	) {
 		return Idea.builder()
 				.user(user)
 				.contest(contest)
 				.title(title)
-				.shortDescription(shortDescription)
-				.description(description)
 				.requestedAt(requestedAt)
 				.build();
 	}
 
-	public void addFile(IdeaFile file) {
-		files.add(file);
-		file.attachTo(this);
-	}
-
-	public void addImage(IdeaImage image) {
-		images.add(image);
-		image.attachTo(this);
+	public void addVersion(IdeaVersion version) {
+		versions.add(version);
+		version.setIdea(this);
 	}
 }

--- a/src/main/java/com/idear/backend/idea/domain/IdeaFile.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaFile.java
@@ -28,10 +28,6 @@ public class IdeaFile {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long ideaFileId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "idea_id", nullable = false)
-	private Idea idea;
-
 	@Column(nullable = false)
 	private String originalFileName;
 
@@ -99,10 +95,6 @@ public class IdeaFile {
 				.commit(commit)
 				.requestedTimestamp(requestedTimestamp)
 				.build();
-	}
-
-	protected void attachTo(Idea idea) {
-		this.idea = idea;
 	}
 
 	public void submitUserSignature(String userSignature, String serverSignature) {

--- a/src/main/java/com/idear/backend/idea/domain/IdeaImage.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaImage.java
@@ -25,10 +25,6 @@ public class IdeaImage {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long ideaImageId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "idea_id", nullable = false)
-	private Idea idea;
-
 	@Column(nullable = false)
 	private String originalFileName;
 
@@ -50,9 +46,5 @@ public class IdeaImage {
 				.fileName(fileName)
 				.filePath(filePath)
 				.build();
-	}
-
-	protected void attachTo(Idea idea) {
-		this.idea = idea;
 	}
 }

--- a/src/main/java/com/idear/backend/idea/domain/IdeaVersion.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaVersion.java
@@ -1,0 +1,117 @@
+package com.idear.backend.idea.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Table(name = "idea_versions")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE idea_versions SET deleted_at = NOW() WHERE idea_version_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class IdeaVersion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ideaVersionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "idea_id", nullable = false)
+    private Idea idea;
+
+    @Column(nullable = false)
+    private Integer versionNumber;
+
+    @Column(length = 255)
+    private String shortDescription;
+
+    @Lob
+    private String description;
+
+    @OneToMany(mappedBy = "ideaVersion", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private Set<IdeaVersionFile> versionFiles = new HashSet<>();
+
+    @OneToMany(mappedBy = "ideaVersion", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private Set<IdeaVersionImage> versionImages = new HashSet<>();
+
+    private LocalDateTime requestedAt;
+
+    private LocalDateTime deletedAt;
+
+    public static IdeaVersion createInitialVersion(
+            String shortDescription,
+            String description,
+            LocalDateTime requestedAt
+    ) {
+        return IdeaVersion.builder()
+                .versionNumber(1)
+                .shortDescription(shortDescription)
+                .description(description)
+                .requestedAt(requestedAt)
+                .build();
+    }
+
+    public static IdeaVersion createNewVersion(
+            IdeaVersion previousVersion,
+            Integer newVersionNumber
+    ) {
+        return IdeaVersion.builder()
+                .versionNumber(newVersionNumber)
+                .shortDescription(previousVersion.shortDescription)
+                .description(previousVersion.description)
+                .requestedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void updateMetadata(String shortDescription, String description) {
+        this.shortDescription = shortDescription;
+        this.description = description;
+    }
+
+    public void addFile(IdeaFile file) {
+        IdeaVersionFile versionFile = IdeaVersionFile.of(this, file);
+        versionFiles.add(versionFile);
+    }
+
+    public void addImage(IdeaImage image) {
+        IdeaVersionImage versionImage = IdeaVersionImage.of(this, image);
+        versionImages.add(versionImage);
+    }
+
+    public Set<IdeaFile> getFiles() {
+        return versionFiles.stream()
+                .map(IdeaVersionFile::getIdeaFile)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    public Set<IdeaImage> getImages() {
+        return versionImages.stream()
+                .map(IdeaVersionImage::getIdeaImage)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    public void removeImagesByIds(List<Long> imageIds) {
+        if (imageIds == null || imageIds.isEmpty()) {
+            return;
+        }
+        versionImages.removeIf(vi -> imageIds.contains(vi.getIdeaImage().getIdeaImageId()));
+    }
+
+    protected void setIdea(Idea idea) {
+        this.idea = idea;
+    }
+}

--- a/src/main/java/com/idear/backend/idea/domain/IdeaVersionFile.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaVersionFile.java
@@ -1,0 +1,53 @@
+package com.idear.backend.idea.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+	name = "idea_version_files",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_version_file",
+		columnNames = {"idea_version_id", "idea_file_id"}
+	)
+)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE idea_version_files SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class IdeaVersionFile {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "idea_version_id", nullable = false)
+	private IdeaVersion ideaVersion;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "idea_file_id", nullable = false)
+	private IdeaFile ideaFile;
+
+	@Column(nullable = false)
+	private LocalDateTime addedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static IdeaVersionFile of(IdeaVersion ideaVersion, IdeaFile ideaFile) {
+		return IdeaVersionFile.builder()
+				.ideaVersion(ideaVersion)
+				.ideaFile(ideaFile)
+				.addedAt(LocalDateTime.now())
+				.build();
+	}
+}

--- a/src/main/java/com/idear/backend/idea/domain/IdeaVersionImage.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaVersionImage.java
@@ -1,0 +1,53 @@
+package com.idear.backend.idea.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+	name = "idea_version_images",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_version_image",
+		columnNames = {"idea_version_id", "idea_image_id"}
+	)
+)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE idea_version_images SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class IdeaVersionImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "idea_version_id", nullable = false)
+	private IdeaVersion ideaVersion;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "idea_image_id", nullable = false)
+	private IdeaImage ideaImage;
+
+	@Column(nullable = false)
+	private LocalDateTime addedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static IdeaVersionImage of(IdeaVersion ideaVersion, IdeaImage ideaImage) {
+		return IdeaVersionImage.builder()
+				.ideaVersion(ideaVersion)
+				.ideaImage(ideaImage)
+				.addedAt(LocalDateTime.now())
+				.build();
+	}
+}

--- a/src/main/java/com/idear/backend/idea/dto/request/IdeaUpdateRequest.java
+++ b/src/main/java/com/idear/backend/idea/dto/request/IdeaUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.idear.backend.idea.dto.request;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class IdeaUpdateRequest {
+	private List<Long> deleteFileIds;
+	private List<Long> deleteImageIds;
+	private String shortDescription;
+	private String description;
+}

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaDetailResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaDetailResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.idear.backend.idea.domain.Idea;
+import com.idear.backend.idea.domain.IdeaVersion;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,8 @@ import lombok.Getter;
 @Builder
 public class IdeaDetailResponse {
 	private Long ideaId;
+	private Long ideaVersionId;
+	private Integer versionNumber;
 	private String title;
 	private String shortDescription;
 	private String description;
@@ -20,21 +23,23 @@ public class IdeaDetailResponse {
 	private List<IdeaFileInfo> files;
 	private List<IdeaImageInfo> images;
 
-	public static IdeaDetailResponse of(Idea idea) {
-		List<IdeaFileInfo> fileInfos = idea.getFiles().stream()
+	public static IdeaDetailResponse of(Idea idea, IdeaVersion version) {
+		List<IdeaFileInfo> fileInfos = version.getFiles().stream()
 				.map(IdeaFileInfo::of)
 				.collect(Collectors.toList());
 
-		List<IdeaImageInfo> imageInfos = idea.getImages().stream()
+		List<IdeaImageInfo> imageInfos = version.getImages().stream()
 				.map(IdeaImageInfo::of)
 				.collect(Collectors.toList());
 
 		return IdeaDetailResponse.builder()
 				.ideaId(idea.getIdeaId())
+				.ideaVersionId(version.getIdeaVersionId())
+				.versionNumber(version.getVersionNumber())
 				.title(idea.getTitle())
-				.shortDescription(idea.getShortDescription())
-				.description(idea.getDescription())
-				.requestedAt(idea.getRequestedAt())
+				.shortDescription(version.getShortDescription())
+				.description(version.getDescription())
+				.requestedAt(version.getRequestedAt())
 				.files(fileInfos)
 				.images(imageInfos)
 				.build();

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaUpdateResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.idear.backend.idea.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IdeaUpdateResponse {
+	private Long ideaId;
+	private Integer versionNumber;
+	private LocalDateTime updatedAt;
+	private List<FileHashInfo> files;
+}

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaWithVersionsResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaWithVersionsResponse.java
@@ -1,0 +1,35 @@
+package com.idear.backend.idea.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.idear.backend.idea.domain.Idea;
+import com.idear.backend.idea.domain.IdeaVersion;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IdeaWithVersionsResponse {
+	private Long ideaId;
+	private String title;
+	private Long contestId;
+	private LocalDateTime requestedAt;
+	private List<VersionDetailInfo> versions;
+
+	public static IdeaWithVersionsResponse of(Idea idea, List<IdeaVersion> versions) {
+		List<VersionDetailInfo> versionInfos = versions.stream()
+				.map(VersionDetailInfo::of)
+				.collect(Collectors.toList());
+
+		return IdeaWithVersionsResponse.builder()
+				.ideaId(idea.getIdeaId())
+				.title(idea.getTitle())
+				.contestId(idea.getContest() != null ? idea.getContest().getContestId() : null)
+				.requestedAt(idea.getRequestedAt())
+				.versions(versionInfos)
+				.build();
+	}
+}

--- a/src/main/java/com/idear/backend/idea/dto/response/VersionDetailInfo.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/VersionDetailInfo.java
@@ -1,38 +1,42 @@
 package com.idear.backend.idea.dto.response;
 
-import com.idear.backend.idea.domain.Idea;
-import com.idear.backend.idea.domain.IdeaVersion;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.idear.backend.idea.domain.IdeaVersion;
+
+import lombok.Builder;
+import lombok.Getter;
+
 @Getter
 @Builder
-public class IdeaSummaryResponse {
-	private Long ideaId;
+public class VersionDetailInfo {
 	private Long ideaVersionId;
 	private Integer versionNumber;
-	private String title;
 	private String shortDescription;
+	private String description;
 	private LocalDateTime requestedAt;
+	private List<IdeaFileInfo> files;
 	private List<IdeaImageInfo> images;
 
-	public static IdeaSummaryResponse of(Idea idea, IdeaVersion version) {
-		List<IdeaImageInfo> imageResponses = version.getImages().stream()
+	public static VersionDetailInfo of(IdeaVersion version) {
+		List<IdeaFileInfo> fileInfos = version.getFiles().stream()
+				.map(IdeaFileInfo::of)
+				.collect(Collectors.toList());
+
+		List<IdeaImageInfo> imageInfos = version.getImages().stream()
 				.map(IdeaImageInfo::of)
 				.collect(Collectors.toList());
 
-		return IdeaSummaryResponse.builder()
-				.ideaId(idea.getIdeaId())
+		return VersionDetailInfo.builder()
 				.ideaVersionId(version.getIdeaVersionId())
 				.versionNumber(version.getVersionNumber())
-				.title(idea.getTitle())
 				.shortDescription(version.getShortDescription())
+				.description(version.getDescription())
 				.requestedAt(version.getRequestedAt())
-				.images(imageResponses)
+				.files(fileInfos)
+				.images(imageInfos)
 				.build();
 	}
 }

--- a/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaRepository.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaRepository.java
@@ -1,12 +1,19 @@
 package com.idear.backend.idea.infrastructure.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.idear.backend.idea.domain.Idea;
+import com.idear.backend.idea.domain.IdeaFile;
 import com.idear.backend.user.domain.User;
 
 public interface IdeaRepository extends JpaRepository<Idea, Long> {
 	List<Idea> findAllByUser(User user);
+
+	@Query("SELECT vf.ideaVersion.idea FROM IdeaVersionFile vf WHERE vf.ideaFile = :ideaFile")
+	Optional<Idea> findIdeaByFile(@Param("ideaFile") IdeaFile ideaFile);
 }

--- a/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaVersionRepository.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaVersionRepository.java
@@ -1,0 +1,34 @@
+package com.idear.backend.idea.infrastructure.repository;
+
+import com.idear.backend.idea.domain.Idea;
+import com.idear.backend.idea.domain.IdeaVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface IdeaVersionRepository extends JpaRepository<IdeaVersion, Long> {
+
+	List<IdeaVersion> findAllByIdeaOrderByVersionNumberDesc(Idea idea);
+
+	@Query("SELECT MAX(v.versionNumber) FROM IdeaVersion v WHERE v.idea = :idea")
+	Optional<Integer> findMaxVersionNumberByIdea(@Param("idea") Idea idea);
+
+	@Query("SELECT v FROM IdeaVersion v " +
+		   "WHERE v.idea = :idea " +
+		   "ORDER BY v.versionNumber DESC " +
+		   "LIMIT 1")
+	Optional<IdeaVersion> findLatestByIdea(@Param("idea") Idea idea);
+
+	@Query("SELECT DISTINCT v FROM IdeaVersion v " +
+		   "LEFT JOIN FETCH v.versionFiles vf " +
+		   "LEFT JOIN FETCH vf.ideaFile " +
+		   "LEFT JOIN FETCH v.versionImages vi " +
+		   "LEFT JOIN FETCH vi.ideaImage " +
+		   "WHERE v.idea = :idea " +
+		   "ORDER BY v.versionNumber DESC " +
+		   "LIMIT 1")
+	Optional<IdeaVersion> findLatestByIdeaWithFilesAndImages(@Param("idea") Idea idea);
+}

--- a/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaVersionRepository.java
+++ b/src/main/java/com/idear/backend/idea/infrastructure/repository/IdeaVersionRepository.java
@@ -16,11 +16,7 @@ public interface IdeaVersionRepository extends JpaRepository<IdeaVersion, Long> 
 	@Query("SELECT MAX(v.versionNumber) FROM IdeaVersion v WHERE v.idea = :idea")
 	Optional<Integer> findMaxVersionNumberByIdea(@Param("idea") Idea idea);
 
-	@Query("SELECT v FROM IdeaVersion v " +
-		   "WHERE v.idea = :idea " +
-		   "ORDER BY v.versionNumber DESC " +
-		   "LIMIT 1")
-	Optional<IdeaVersion> findLatestByIdea(@Param("idea") Idea idea);
+	Optional<IdeaVersion> findTopByIdeaOrderByVersionNumberDesc(Idea idea);
 
 	@Query("SELECT DISTINCT v FROM IdeaVersion v " +
 		   "LEFT JOIN FETCH v.versionFiles vf " +

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ secret:
   jwt:
     key: ${JWT_KEY}
     access:
-      expiration: 3600000
+      expiration: 1209600000
     refresh:
       expiration: 1209600000
 


### PR DESCRIPTION
### 연관된 이슈

> #39 

### 작업 내용

- IdeaVersion 엔티티 추가로 Idea와 파일/이미지 간 버전 관리계층 구축
- IdeaVersionFile, IdeaVersionImage 조인 테이블 설정(M:N 관계)
- Idea 엔티티에서 shortDescription, description, files, images를 IdeaVersion으로 이동
- 아이디어 수정 API 추가 (PATCH /ideas/{ideaId})
- 파일/이미지 변경 시 새 버전 자동 생성
- 메타데이터만 변경 시 기존 버전 수정
