### PR TITLE
feat: IdeaVersion에 githubUrl, figmaUrl 필드 추가 및 기존 로직 병합 (#41)

### DIFF
--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -72,6 +72,8 @@ public class IdeaService {
 		IdeaVersion initialVersion = IdeaVersion.createInitialVersion(
 				request.getShortDescription(),
 				request.getDescription(),
+				request.getGithubUrl(),
+				request.getFigmaUrl(),
 				requestedAt
 		);
 		idea.addVersion(initialVersion);
@@ -113,11 +115,7 @@ public class IdeaService {
 				throw CustomException.of(ErrorCode.IDEA_FILE_IDEA_MISMATCH);
 			}
 
-			String userSignature = signatureData.getUserSignature();
-
-			if (!userSignature.startsWith("0x")) {
-				userSignature = "0x" + userSignature;
-			}
+			String userSignature = normalizeSignature(signatureData.getUserSignature());
 
 			String serverSignature = serverSignatureService.generateServerSignature(
 					ideaFile.getCommit(),
@@ -134,19 +132,84 @@ public class IdeaService {
 					serverSignature
 			);
 
-			registrationResults.add(FileRegistrationResult.builder()
-					.ideaFileId(ideaFile.getIdeaFileId())
-					.fileName(ideaFile.getOriginalFileName())
-					.fileHash(ideaFile.getFileHash())
-					.salt(ideaFile.getSalt())
-					.commit(ideaFile.getCommit())
-					.build());
+			registrationResults.add(FileRegistrationResult.of(ideaFile));
 		}
 
 		return IdeaRegistrationCompleteResponse.builder()
 				.ideaId(ideaId)
 				.registeredFiles(registrationResults)
 				.totalFiles(registrationResults.size())
+				.build();
+	}
+
+	@Transactional
+	public IdeaUpdateResponse updateIdea(
+			User user,
+			Long ideaId,
+			List<Long> deleteFileIds,
+			List<Long> deleteImageIds,
+			String shortDescription,
+			String description,
+			String githubUrl,
+			String figmaUrl,
+			List<MultipartFile> images,
+			List<MultipartFile> files
+	) throws IOException {
+		Idea idea = ideaRepository.findById(ideaId)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
+
+		if (!idea.getUser().getUserId().equals(user.getUserId())) {
+			throw CustomException.of(ErrorCode.USER_NOT_OWNER);
+		}
+
+		IdeaVersion latestVersion = ideaVersionRepository
+				.findLatestByIdeaWithFilesAndImages(idea)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
+
+		boolean hasFileChanges = (deleteFileIds != null && !deleteFileIds.isEmpty())
+				|| hasNonEmptyFiles(files);
+
+		IdeaVersion targetVersion;
+		List<FileHashInfo> fileHashInfoList = new ArrayList<>();
+		LocalDateTime updatedAt = LocalDateTime.now();
+		Long timestamp = updatedAt.toEpochSecond(ZoneOffset.UTC);
+
+		if (hasFileChanges) {
+			Integer maxVersionNumber = ideaVersionRepository
+					.findMaxVersionNumberByIdea(idea)
+					.orElse(0);
+
+			IdeaVersion newVersion = IdeaVersion.createNewVersion(
+					latestVersion,
+					maxVersionNumber + 1
+			);
+			idea.addVersion(newVersion);
+			newVersion = ideaVersionRepository.save(newVersion);
+
+			copyImagesFromPreviousVersion(newVersion, latestVersion, deleteImageIds);
+			copyFilesFromPreviousVersion(newVersion, latestVersion, deleteFileIds);
+
+			fileHashInfoList = processFiles(newVersion, files, timestamp);
+			newVersion.updateMetadataIfNeeded(shortDescription, description, githubUrl, figmaUrl);
+
+			targetVersion = newVersion;
+		} else {
+			latestVersion.updateMetadataIfNeeded(shortDescription, description, githubUrl, figmaUrl);
+			targetVersion = latestVersion;
+		}
+
+		// 메타만 변경 시 이미지 관계 제거
+		if (!hasFileChanges && deleteImageIds != null && !deleteImageIds.isEmpty()) {
+			targetVersion.removeImagesByIds(deleteImageIds);
+		}
+
+		processImages(targetVersion, images);
+
+		return IdeaUpdateResponse.builder()
+				.ideaId(ideaId)
+				.versionNumber(targetVersion.getVersionNumber())
+				.updatedAt(updatedAt)
+				.files(fileHashInfoList)
 				.build();
 	}
 
@@ -260,99 +323,30 @@ public class IdeaService {
 		return fileHashInfoList;
 	}
 
-	@Transactional
-	public IdeaUpdateResponse updateIdea(
-		User user,
-		Long ideaId,
-		List<Long> deleteFileIds,
-		List<Long> deleteImageIds,
-		String shortDescription,
-		String description,
-		List<MultipartFile> images,
-		List<MultipartFile> files
-	) throws IOException {
-		Idea idea = ideaRepository.findById(ideaId)
-				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
-
-		if (!idea.getUser().getUserId().equals(user.getUserId())) {
-			throw CustomException.of(ErrorCode.USER_NOT_OWNER);
+	private String normalizeSignature(String signature) {
+		if (signature != null && !signature.startsWith("0x")) {
+			return "0x" + signature;
 		}
+		return signature;
+	}
 
-		IdeaVersion latestVersion = ideaVersionRepository
-				.findLatestByIdeaWithFilesAndImages(idea)
-				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
-
-		boolean hasFileChanges = (deleteFileIds != null && !deleteFileIds.isEmpty())
-				|| hasNonEmptyFiles(files);
-
-		IdeaVersion targetVersion;
-		List<FileHashInfo> fileHashInfoList = new ArrayList<>();
-		LocalDateTime updatedAt = LocalDateTime.now();
-		Long timestamp = updatedAt.toEpochSecond(ZoneOffset.UTC);
-
-		if (hasFileChanges) {
-			Integer maxVersionNumber = ideaVersionRepository
-				.findMaxVersionNumberByIdea(idea)
-				.orElse(0);
-
-			IdeaVersion newVersion = IdeaVersion.createNewVersion(
-				latestVersion,
-				maxVersionNumber + 1
-			);
-			idea.addVersion(newVersion);
-			newVersion = ideaVersionRepository.save(newVersion);
-
-			// 이미지 참조 복사 (Join Entity)
-			Set<IdeaImage> imagesToKeep = new HashSet<>(latestVersion.getImages());
-			if (deleteImageIds != null && !deleteImageIds.isEmpty()) {
-				imagesToKeep.removeIf(img -> deleteImageIds.contains(img.getIdeaImageId()));
-			}
-			for (IdeaImage image : imagesToKeep) {
-				newVersion.addImage(image);
-			}
-
-			// 파일 참조 복사 (Join Entity)
-			Set<IdeaFile> filesToKeep = new HashSet<>(latestVersion.getFiles());
-			if (deleteFileIds != null && !deleteFileIds.isEmpty()) {
-				filesToKeep.removeIf(file -> deleteFileIds.contains(file.getIdeaFileId()));
-			}
-			for (IdeaFile file : filesToKeep) {
-				newVersion.addFile(file);
-			}
-
-			fileHashInfoList = processFiles(newVersion, files, timestamp);
-
-			if (shortDescription != null || description != null) {
-				newVersion.updateMetadata(
-					shortDescription != null ? shortDescription : newVersion.getShortDescription(),
-					description != null ? description : newVersion.getDescription()
-				);
-			}
-
-			targetVersion = newVersion;
-		} else {
-			if (shortDescription != null || description != null) {
-				latestVersion.updateMetadata(
-					shortDescription != null ? shortDescription : latestVersion.getShortDescription(),
-					description != null ? description : latestVersion.getDescription()
-				);
-			}
-
-			targetVersion = latestVersion;
+	private void copyImagesFromPreviousVersion(IdeaVersion newVersion, IdeaVersion previousVersion, List<Long> deleteImageIds) {
+		Set<IdeaImage> imagesToKeep = new HashSet<>(previousVersion.getImages());
+		if (deleteImageIds != null && !deleteImageIds.isEmpty()) {
+			imagesToKeep.removeIf(img -> deleteImageIds.contains(img.getIdeaImageId()));
 		}
-
-		// 메타만 변경 시 이미지 관계 제거
-		if (!hasFileChanges && deleteImageIds != null && !deleteImageIds.isEmpty()) {
-			targetVersion.removeImagesByIds(deleteImageIds);
+		for (IdeaImage image : imagesToKeep) {
+			newVersion.addImage(image);
 		}
+	}
 
-		processImages(targetVersion, images);
-
-		return IdeaUpdateResponse.builder()
-			.ideaId(ideaId)
-			.versionNumber(targetVersion.getVersionNumber())
-			.updatedAt(updatedAt)
-			.files(fileHashInfoList)
-			.build();
+	private void copyFilesFromPreviousVersion(IdeaVersion newVersion, IdeaVersion previousVersion, List<Long> deleteFileIds) {
+		Set<IdeaFile> filesToKeep = new HashSet<>(previousVersion.getFiles());
+		if (deleteFileIds != null && !deleteFileIds.isEmpty()) {
+			filesToKeep.removeIf(file -> deleteFileIds.contains(file.getIdeaFileId()));
+		}
+		for (IdeaFile file : filesToKeep) {
+			newVersion.addFile(file);
+		}
 	}
 }

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -81,10 +81,12 @@ public class IdeaController {
 		List<Long> deleteImageIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteImageIds() : null;
 		String shortDescription = ideaUpdateRequest != null ? ideaUpdateRequest.getShortDescription() : null;
 		String description = ideaUpdateRequest != null ? ideaUpdateRequest.getDescription() : null;
+		String githubUrl = ideaUpdateRequest != null ? ideaUpdateRequest.getGithubUrl() : null;
+		String figmaUrl = ideaUpdateRequest != null ? ideaUpdateRequest.getFigmaUrl() : null;
 
 		IdeaUpdateResponse response = ideaService.updateIdea(
 				user, ideaId, deleteFileIds, deleteImageIds,
-				shortDescription, description, images, files
+				shortDescription, description, githubUrl, figmaUrl, images, files
 		);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}

--- a/src/main/java/com/idear/backend/idea/domain/IdeaVersion.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaVersion.java
@@ -40,6 +40,12 @@ public class IdeaVersion {
     @Lob
     private String description;
 
+    @Column(length = 255)
+    private String githubUrl;
+
+    @Column(length = 255)
+    private String figmaUrl;
+
     @OneToMany(mappedBy = "ideaVersion", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private Set<IdeaVersionFile> versionFiles = new HashSet<>();
@@ -55,12 +61,16 @@ public class IdeaVersion {
     public static IdeaVersion createInitialVersion(
             String shortDescription,
             String description,
+            String githubUrl,
+            String figmaUrl,
             LocalDateTime requestedAt
     ) {
         return IdeaVersion.builder()
                 .versionNumber(1)
                 .shortDescription(shortDescription)
                 .description(description)
+                .githubUrl(githubUrl)
+                .figmaUrl(figmaUrl)
                 .requestedAt(requestedAt)
                 .build();
     }
@@ -73,13 +83,17 @@ public class IdeaVersion {
                 .versionNumber(newVersionNumber)
                 .shortDescription(previousVersion.shortDescription)
                 .description(previousVersion.description)
+                .githubUrl(previousVersion.githubUrl)
+                .figmaUrl(previousVersion.figmaUrl)
                 .requestedAt(LocalDateTime.now())
                 .build();
     }
 
-    public void updateMetadata(String shortDescription, String description) {
-        this.shortDescription = shortDescription;
-        this.description = description;
+    public void updateMetadataIfNeeded(String shortDescription, String description, String githubUrl, String figmaUrl) {
+        this.shortDescription = shortDescription != null ? shortDescription : this.shortDescription;
+        this.description = description != null ? description : this.description;
+        this.githubUrl = githubUrl != null ? githubUrl : this.githubUrl;
+        this.figmaUrl = figmaUrl != null ? figmaUrl : this.figmaUrl;
     }
 
     public void addFile(IdeaFile file) {

--- a/src/main/java/com/idear/backend/idea/dto/request/IdeaCreateRequest.java
+++ b/src/main/java/com/idear/backend/idea/dto/request/IdeaCreateRequest.java
@@ -12,4 +12,6 @@ public class IdeaCreateRequest {
 	private String shortDescription;
 	@NotNull
 	private String description;
+	private String githubUrl;
+	private String figmaUrl;
 }

--- a/src/main/java/com/idear/backend/idea/dto/request/IdeaUpdateRequest.java
+++ b/src/main/java/com/idear/backend/idea/dto/request/IdeaUpdateRequest.java
@@ -10,4 +10,6 @@ public class IdeaUpdateRequest {
 	private List<Long> deleteImageIds;
 	private String shortDescription;
 	private String description;
+	private String githubUrl;
+	private String figmaUrl;
 }

--- a/src/main/java/com/idear/backend/idea/dto/response/FileRegistrationResult.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/FileRegistrationResult.java
@@ -1,5 +1,6 @@
 package com.idear.backend.idea.dto.response;
 
+import com.idear.backend.idea.domain.IdeaFile;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +12,14 @@ public class FileRegistrationResult {
 	private String fileHash;
 	private String salt;
 	private String commit;
+
+	public static FileRegistrationResult of(IdeaFile ideaFile) {
+		return FileRegistrationResult.builder()
+				.ideaFileId(ideaFile.getIdeaFileId())
+				.fileName(ideaFile.getOriginalFileName())
+				.fileHash(ideaFile.getFileHash())
+				.salt(ideaFile.getSalt())
+				.commit(ideaFile.getCommit())
+				.build();
+	}
 }

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaSummaryResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaSummaryResponse.java
@@ -17,6 +17,8 @@ public class IdeaSummaryResponse {
 	private Integer versionNumber;
 	private String title;
 	private String shortDescription;
+	private String githubUrl;
+	private String figmaUrl;
 	private LocalDateTime requestedAt;
 	private List<IdeaImageInfo> images;
 
@@ -31,6 +33,8 @@ public class IdeaSummaryResponse {
 				.versionNumber(version.getVersionNumber())
 				.title(idea.getTitle())
 				.shortDescription(version.getShortDescription())
+				.githubUrl(version.getGithubUrl())
+				.figmaUrl(version.getFigmaUrl())
 				.requestedAt(version.getRequestedAt())
 				.images(imageResponses)
 				.build();

--- a/src/main/java/com/idear/backend/idea/dto/response/VersionDetailInfo.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/VersionDetailInfo.java
@@ -16,6 +16,8 @@ public class VersionDetailInfo {
 	private Integer versionNumber;
 	private String shortDescription;
 	private String description;
+	private String githubUrl;
+	private String figmaUrl;
 	private LocalDateTime requestedAt;
 	private List<IdeaFileInfo> files;
 	private List<IdeaImageInfo> images;
@@ -34,6 +36,8 @@ public class VersionDetailInfo {
 				.versionNumber(version.getVersionNumber())
 				.shortDescription(version.getShortDescription())
 				.description(version.getDescription())
+				.githubUrl(version.getGithubUrl())
+				.figmaUrl(version.getFigmaUrl())
 				.requestedAt(version.getRequestedAt())
 				.files(fileInfos)
 				.images(imageInfos)


### PR DESCRIPTION
### 연관된 이슈

> Closes #41 

### 작업 내용

- IdeaVersion에 githubUrl, figmaUrl 필드 추가
- 기존 Idea 생성 및 수정 로직에 해당 필드 적용
- IdeaService 중복 코드 정리를 위한 메소드 추출 진행
- IdeaService 가독성 향상을 위해 Builder DTO 내부로 이동
