### PR TITLE
feat: title 정보를 Idea에서 IdeaVersion으로 이동 

### DIFF
--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -11,6 +11,7 @@ import com.idear.backend.idea.domain.IdeaImage;
 import com.idear.backend.idea.domain.IdeaVersion;
 import com.idear.backend.idea.dto.request.FileSignatureRequest;
 import com.idear.backend.idea.dto.request.IdeaCreateRequest;
+import com.idear.backend.idea.dto.request.IdeaUpdateRequest;
 import com.idear.backend.idea.dto.request.SignatureData;
 import com.idear.backend.idea.dto.response.*;
 import com.idear.backend.idea.infrastructure.repository.IdeaFileRepository;
@@ -146,13 +147,7 @@ public class IdeaService {
 	public IdeaUpdateResponse updateIdea(
 			User user,
 			Long ideaId,
-			List<Long> deleteFileIds,
-			List<Long> deleteImageIds,
-			String title,
-			String shortDescription,
-			String description,
-			String githubUrl,
-			String figmaUrl,
+			IdeaUpdateRequest request,
 			List<MultipartFile> images,
 			List<MultipartFile> files
 	) throws IOException {
@@ -166,6 +161,18 @@ public class IdeaService {
 		IdeaVersion latestVersion = ideaVersionRepository
 				.findLatestByIdeaWithFilesAndImages(idea)
 				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
+
+		if (request == null) {
+			request = new IdeaUpdateRequest();
+		}
+
+		List<Long> deleteFileIds = request.getDeleteFileIds();
+		List<Long> deleteImageIds = request.getDeleteImageIds();
+		String title = request.getTitle();
+		String shortDescription = request.getShortDescription();
+		String description = request.getDescription();
+		String githubUrl = request.getGithubUrl();
+		String figmaUrl = request.getFigmaUrl();
 
 		boolean hasFileChanges = (deleteFileIds != null && !deleteFileIds.isEmpty())
 				|| hasNonEmptyFiles(files);

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -64,12 +64,12 @@ public class IdeaService {
 		Idea idea = Idea.register(
 				user,
 				contest,
-				request.getTitle(),
 				requestedAt
 		);
 		idea = ideaRepository.save(idea);
 
 		IdeaVersion initialVersion = IdeaVersion.createInitialVersion(
+				request.getTitle(),
 				request.getShortDescription(),
 				request.getDescription(),
 				request.getGithubUrl(),
@@ -148,6 +148,7 @@ public class IdeaService {
 			Long ideaId,
 			List<Long> deleteFileIds,
 			List<Long> deleteImageIds,
+			String title,
 			String shortDescription,
 			String description,
 			String githubUrl,
@@ -190,11 +191,11 @@ public class IdeaService {
 			copyFilesFromPreviousVersion(newVersion, latestVersion, deleteFileIds);
 
 			fileHashInfoList = processFiles(newVersion, files, timestamp);
-			newVersion.updateMetadataIfNeeded(shortDescription, description, githubUrl, figmaUrl);
+			newVersion.updateMetadataIfNeeded(title, shortDescription, description, githubUrl, figmaUrl);
 
 			targetVersion = newVersion;
 		} else {
-			latestVersion.updateMetadataIfNeeded(shortDescription, description, githubUrl, figmaUrl);
+			latestVersion.updateMetadataIfNeeded(title, shortDescription, description, githubUrl, figmaUrl);
 			targetVersion = latestVersion;
 		}
 

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -79,13 +79,14 @@ public class IdeaController {
 	) throws IOException {
 		List<Long> deleteFileIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteFileIds() : null;
 		List<Long> deleteImageIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteImageIds() : null;
+		String title = ideaUpdateRequest != null ? ideaUpdateRequest.getTitle() : null;
 		String shortDescription = ideaUpdateRequest != null ? ideaUpdateRequest.getShortDescription() : null;
 		String description = ideaUpdateRequest != null ? ideaUpdateRequest.getDescription() : null;
 		String githubUrl = ideaUpdateRequest != null ? ideaUpdateRequest.getGithubUrl() : null;
 		String figmaUrl = ideaUpdateRequest != null ? ideaUpdateRequest.getFigmaUrl() : null;
 
 		IdeaUpdateResponse response = ideaService.updateIdea(
-				user, ideaId, deleteFileIds, deleteImageIds,
+				user, ideaId, deleteFileIds, deleteImageIds, title,
 				shortDescription, description, githubUrl, figmaUrl, images, files
 		);
 		return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -77,18 +77,7 @@ public class IdeaController {
 			@Parameter(description = "추가할 파일 목록")
 			@RequestPart(value = "files", required = false) List<MultipartFile> files
 	) throws IOException {
-		List<Long> deleteFileIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteFileIds() : null;
-		List<Long> deleteImageIds = ideaUpdateRequest != null ? ideaUpdateRequest.getDeleteImageIds() : null;
-		String title = ideaUpdateRequest != null ? ideaUpdateRequest.getTitle() : null;
-		String shortDescription = ideaUpdateRequest != null ? ideaUpdateRequest.getShortDescription() : null;
-		String description = ideaUpdateRequest != null ? ideaUpdateRequest.getDescription() : null;
-		String githubUrl = ideaUpdateRequest != null ? ideaUpdateRequest.getGithubUrl() : null;
-		String figmaUrl = ideaUpdateRequest != null ? ideaUpdateRequest.getFigmaUrl() : null;
-
-		IdeaUpdateResponse response = ideaService.updateIdea(
-				user, ideaId, deleteFileIds, deleteImageIds, title,
-				shortDescription, description, githubUrl, figmaUrl, images, files
-		);
+		IdeaUpdateResponse response = ideaService.updateIdea(user, ideaId, ideaUpdateRequest, images, files);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 

--- a/src/main/java/com/idear/backend/idea/domain/Idea.java
+++ b/src/main/java/com/idear/backend/idea/domain/Idea.java
@@ -36,9 +36,6 @@ public class Idea {
 	@JoinColumn(name = "contest_id")
 	private Contest contest;
 
-	@Column(nullable = false, length = 100)
-	private String title;
-
 	@OneToMany(mappedBy = "idea", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<IdeaVersion> versions = new ArrayList<>();
@@ -50,13 +47,11 @@ public class Idea {
 	public static Idea register(
 			User user,
 			Contest contest,
-			String title,
 			LocalDateTime requestedAt
 	) {
 		return Idea.builder()
 				.user(user)
 				.contest(contest)
-				.title(title)
 				.requestedAt(requestedAt)
 				.build();
 	}

--- a/src/main/java/com/idear/backend/idea/domain/IdeaVersion.java
+++ b/src/main/java/com/idear/backend/idea/domain/IdeaVersion.java
@@ -35,6 +35,9 @@ public class IdeaVersion {
     @Column(nullable = false)
     private Integer versionNumber;
 
+    @Column(nullable = false, length = 100)
+    private String title;
+
     @Column(length = 255)
     private String shortDescription;
 
@@ -64,6 +67,7 @@ public class IdeaVersion {
     private LocalDateTime deletedAt;
 
     public static IdeaVersion createInitialVersion(
+            String title,
             String shortDescription,
             String description,
             String githubUrl,
@@ -72,6 +76,7 @@ public class IdeaVersion {
     ) {
         return IdeaVersion.builder()
                 .versionNumber(1)
+                .title(title)
                 .shortDescription(shortDescription)
                 .description(description)
                 .githubUrl(githubUrl)
@@ -86,6 +91,7 @@ public class IdeaVersion {
     ) {
         return IdeaVersion.builder()
                 .versionNumber(newVersionNumber)
+                .title(previousVersion.title)
                 .shortDescription(previousVersion.shortDescription)
                 .description(previousVersion.description)
                 .githubUrl(previousVersion.githubUrl)
@@ -94,7 +100,8 @@ public class IdeaVersion {
                 .build();
     }
 
-    public void updateMetadataIfNeeded(String shortDescription, String description, String githubUrl, String figmaUrl) {
+    public void updateMetadataIfNeeded(String title, String shortDescription, String description, String githubUrl, String figmaUrl) {
+        this.title = title != null ? title : this.title;
         this.shortDescription = shortDescription != null ? shortDescription : this.shortDescription;
         this.description = description != null ? description : this.description;
         this.githubUrl = githubUrl != null ? githubUrl : this.githubUrl;

--- a/src/main/java/com/idear/backend/idea/dto/request/IdeaUpdateRequest.java
+++ b/src/main/java/com/idear/backend/idea/dto/request/IdeaUpdateRequest.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class IdeaUpdateRequest {
 	private List<Long> deleteFileIds;
 	private List<Long> deleteImageIds;
+	private String title;
 	private String shortDescription;
 	private String description;
 	private String githubUrl;

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaSummaryResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaSummaryResponse.java
@@ -44,7 +44,7 @@ public class IdeaSummaryResponse {
 				.ideaId(idea.getIdeaId())
 				.ideaVersionId(version.getIdeaVersionId())
 				.versionNumber(version.getVersionNumber())
-				.title(idea.getTitle())
+				.title(version.getTitle())
 				.host(host)
 				.dday(dDay)
 				.contestImageUrl(contestImageUrl)

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaWithVersionsResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaWithVersionsResponse.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 @Builder
 public class IdeaWithVersionsResponse {
 	private Long ideaId;
-	private String title;
 	private Long contestId;
 	private String contestTitle;
 	private LocalDateTime requestedAt;
@@ -34,7 +33,6 @@ public class IdeaWithVersionsResponse {
 
 		return IdeaWithVersionsResponse.builder()
 				.ideaId(idea.getIdeaId())
-				.title(idea.getTitle())
 				.contestId(contestId)
 				.contestTitle(contestTitle)
 				.requestedAt(idea.getRequestedAt())

--- a/src/main/java/com/idear/backend/idea/dto/response/VersionDetailInfo.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/VersionDetailInfo.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 public class VersionDetailInfo {
 	private Long ideaVersionId;
 	private Integer versionNumber;
+	private String title;
 	private String shortDescription;
 	private String description;
 	private String githubUrl;
@@ -39,6 +40,7 @@ public class VersionDetailInfo {
 		return VersionDetailInfo.builder()
 				.ideaVersionId(version.getIdeaVersionId())
 				.versionNumber(version.getVersionNumber())
+				.title(version.getTitle())
 				.shortDescription(version.getShortDescription())
 				.description(version.getDescription())
 				.githubUrl(version.getGithubUrl())


### PR DESCRIPTION
### 작업 내용

- title 정보를 IdeaVersion으로 이동
- title을 다른 메타데이터 처럼 버전별 관리 및 기존 로직에 반영
- updateIdea()의 불필요한 null 체크 삭제 및 파라미터 간소화