### PR TITLE
fix: CD workflow에서 docker run 대상 image name이 grim으로 변경되는 문제 해결

### DIFF
--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -56,6 +56,9 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_KEY }}
           script: |
+            echo "WORKFLOW=$GITHUB_WORKFLOW REF=$GITHUB_REF SHA=$GITHUB_SHA RUN_ID=$GITHUB_RUN_ID"
+            date
+            
             set -e
 
             DOCKER_NETWORK="idear-net"

--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -91,6 +91,10 @@ jobs:
             sudo docker rmi -f ${IMAGE_NAME} || true
             sudo docker pull ${IMAGE_NAME}
 
+            echo "IMAGE_NAME=[$IMAGE_NAME]"
+            printf 'IMAGE_NAME(shell-escaped)=%q\n' "$IMAGE_NAME"
+            set -x
+            
             echo "Running the new container with image: ${IMAGE_NAME}"
             sudo docker run --name ${CONTAINER_NAME} -d \
                  --network ${DOCKER_NETWORK} \

--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -49,83 +49,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@master
+      - uses: actions/checkout@v3
+
+      - name: Upload deploy.sh to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_KEY }}
+          source: "deploy/deploy.sh"
+          target: "/home/ubuntu"
+
+      - name: Run deploy.sh on EC2
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_KEY }}
           script: |
-            echo "WORKFLOW=$GITHUB_WORKFLOW REF=$GITHUB_REF SHA=$GITHUB_SHA RUN_ID=$GITHUB_RUN_ID"
-            date
-            
-            set -e
+            chmod +x /home/ubuntu/deploy/deploy.sh
 
-            DOCKER_NETWORK="idear-net"
-            REDIS_CONTAINER_NAME="redis"
-            IMAGE_NAME="${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest"
-            CONTAINER_NAME="idear-api"
-
-            sudo docker network inspect ${DOCKER_NETWORK} >/dev/null 2>&1 || sudo docker network create ${DOCKER_NETWORK}
-
-            if ! sudo docker ps -a --format '{{.Names}}' | grep -qx ${REDIS_CONTAINER_NAME}; then
-              sudo docker run -d \
-                --name ${REDIS_CONTAINER_NAME} \
-                --network ${DOCKER_NETWORK} \
-                --restart unless-stopped \
-                redis:7-alpine
-            else
-              sudo docker network connect ${DOCKER_NETWORK} ${REDIS_CONTAINER_NAME} >/dev/null 2>&1 || true
-
-              if ! sudo docker ps --format '{{.Names}}' | grep -qx ${REDIS_CONTAINER_NAME}; then
-                sudo docker start ${REDIS_CONTAINER_NAME}
-              fi
-            fi
-
-            CONTAINER_ID=$(sudo docker ps -aqf "name=^/${CONTAINER_NAME}$")
-            if [ -n "$CONTAINER_ID" ]; then
-              echo "Stopping existing container: $CONTAINER_ID"
-              sudo docker stop $CONTAINER_ID
-              sudo docker rm $CONTAINER_ID
-            else
-              echo "No existing container to stop."
-            fi
-
-            sudo docker rmi -f ${IMAGE_NAME} || true
-            sudo docker pull ${IMAGE_NAME}
-
-            echo "IMAGE_NAME=[$IMAGE_NAME]"
-            printf 'IMAGE_NAME(shell-escaped)=%q\n' "$IMAGE_NAME"
-            set -x
-            
-            echo "Running the new container with image: ${IMAGE_NAME}"
-            sudo docker run --name ${CONTAINER_NAME} -d \
-                 --network ${DOCKER_NETWORK} \
-                 -p 8080:8080 \
-                 -e SPRING_PROFILES_ACTIVE=prod \
-                 -e IDEAR_CRAWLER_ENABLED=false \
-                 -e PROD_MYSQL_URL=${{ secrets.PROD_MYSQL_URL }} \
-                 -e PROD_MYSQL_USER=${{ secrets.PROD_MYSQL_USER }} \
-                 -e PROD_MYSQL_PASSWORD=${{ secrets.PROD_MYSQL_PASSWORD }} \
-                 -e REDIS_HOST=${REDIS_CONTAINER_NAME} \
-                 -e REDIS_PORT=6379 \
-                 -e JWT_KEY=${{ secrets.JWT_KEY }} \
-                 -e FRONT_ORIGIN=${{ secrets.FRONT_ORIGIN }} \
-                 -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} \
-                 -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} \
-                 -e KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} \
-                 -e KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }} \
-                 -e KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }} \
-                 -e NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} \
-                 -e NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} \
-                 -e NAVER_REDIRECT_URI=${{ secrets.NAVER_REDIRECT_URI }} \
-                 -e GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
-                 -e GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
-                 -e GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }} \
-                 -e BLOCKCHAIN_GATEWAY_URL=http://idear-chain:3000 \
-                 -e SERVER_PRIVATE_KEY=${{ secrets.SERVER_PRIVATE_KEY }} \
-                 -e SPRING_MAIL_USERNAME=${{ secrets.SPRING_MAIL_USERNAME }} \
-                 -e SPRING_MAIL_PASSWORD=${{ secrets.SPRING_MAIL_PASSWORD }} \
-                 "${IMAGE_NAME}"
-
-            sudo docker system prune -f
+            DOCKERHUB_USERNAME='${{ secrets.DOCKERHUB_USERNAME }}' \
+            DOCKER_IMAGE_NAME='${{ secrets.DOCKER_IMAGE_NAME }}' \
+            PROD_MYSQL_URL='${{ secrets.PROD_MYSQL_URL }}' \
+            PROD_MYSQL_USER='${{ secrets.PROD_MYSQL_USER }}' \
+            PROD_MYSQL_PASSWORD='${{ secrets.PROD_MYSQL_PASSWORD }}' \
+            JWT_KEY='${{ secrets.JWT_KEY }}' \
+            FRONT_ORIGIN='${{ secrets.FRONT_ORIGIN }}' \
+            S3_ACCESS_KEY='${{ secrets.S3_ACCESS_KEY }}' \
+            S3_SECRET_KEY='${{ secrets.S3_SECRET_KEY }}' \
+            KAKAO_CLIENT_ID='${{ secrets.KAKAO_CLIENT_ID }}' \
+            KAKAO_CLIENT_SECRET='${{ secrets.KAKAO_CLIENT_SECRET }}' \
+            KAKAO_REDIRECT_URI='${{ secrets.KAKAO_REDIRECT_URI }}' \
+            NAVER_CLIENT_ID='${{ secrets.NAVER_CLIENT_ID }}' \
+            NAVER_CLIENT_SECRET='${{ secrets.NAVER_CLIENT_SECRET }}' \
+            NAVER_REDIRECT_URI='${{ secrets.NAVER_REDIRECT_URI }}' \
+            GOOGLE_CLIENT_ID='${{ secrets.GOOGLE_CLIENT_ID }}' \
+            GOOGLE_CLIENT_SECRET='${{ secrets.GOOGLE_CLIENT_SECRET }}' \
+            GOOGLE_REDIRECT_URI='${{ secrets.GOOGLE_REDIRECT_URI }}' \
+            SERVER_PRIVATE_KEY='${{ secrets.SERVER_PRIVATE_KEY }}' \
+            SPRING_MAIL_USERNAME='${{ secrets.SPRING_MAIL_USERNAME }}' \
+            SPRING_MAIL_PASSWORD='${{ secrets.SPRING_MAIL_PASSWORD }}' \
+            bash /home/ubuntu/deploy/deploy.sh

--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - 'fix/cd-workflow'
 
 permissions:
   contents: read
@@ -31,7 +32,7 @@ jobs:
           arguments: clean bootJar
 
       - name: docker image build
-        run: docker build -f Dockerfile.api -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }} .
+        run: docker build -f Dockerfile.api -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest .
 
       - name: docker login
         uses: docker/login-action@v2
@@ -40,7 +41,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: docker Hub push
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest
 
   deploy-to-ec2:
     if: github.event_name == 'push'
@@ -59,7 +60,7 @@ jobs:
 
             DOCKER_NETWORK="idear-net"
             REDIS_CONTAINER_NAME="redis"
-            IMAGE_NAME="${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}"
+            IMAGE_NAME="${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest"
             CONTAINER_NAME="idear-api"
 
             sudo docker network inspect ${DOCKER_NETWORK} >/dev/null 2>&1 || sudo docker network create ${DOCKER_NETWORK}
@@ -120,4 +121,4 @@ jobs:
                  -e SPRING_MAIL_PASSWORD=${{ secrets.SPRING_MAIL_PASSWORD }} \
                  ${IMAGE_NAME}
 
-            sudo docker system prune -a -f
+            sudo docker system prune -f

--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -123,6 +123,6 @@ jobs:
                  -e SERVER_PRIVATE_KEY=${{ secrets.SERVER_PRIVATE_KEY }} \
                  -e SPRING_MAIL_USERNAME=${{ secrets.SPRING_MAIL_USERNAME }} \
                  -e SPRING_MAIL_PASSWORD=${{ secrets.SPRING_MAIL_PASSWORD }} \
-                 ${IMAGE_NAME}
+                 "${IMAGE_NAME}"
 
             sudo docker system prune -f

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -24,16 +24,12 @@ fi
 
 CONTAINER_ID=$(sudo docker ps -aqf "name=^/${CONTAINER_NAME}$")
 if [ -n "${CONTAINER_ID}" ]; then
-  echo "Stopping existing container: ${CONTAINER_ID}"
   sudo docker stop "${CONTAINER_ID}"
   sudo docker rm "${CONTAINER_ID}"
-else
-  echo "No existing container to stop."
 fi
 
 sudo docker pull "${IMAGE_NAME}"
 
-echo "Running the new container with image: ${IMAGE_NAME}"
 sudo docker run --name "${CONTAINER_NAME}" -d \
   --network "${DOCKER_NETWORK}" \
   -p 8080:8080 \
@@ -63,4 +59,4 @@ sudo docker run --name "${CONTAINER_NAME}" -d \
   -e SPRING_MAIL_PASSWORD="${SPRING_MAIL_PASSWORD}" \
   "${IMAGE_NAME}"
 
-sudo docker system prune -f
+sudo docker system prune -a -f

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER_NETWORK="idear-net"
+REDIS_CONTAINER_NAME="redis"
+CONTAINER_NAME="idear-api"
+IMAGE_NAME="${DOCKERHUB_USERNAME}/${DOCKER_IMAGE_NAME}:latest"
+
+sudo docker network inspect "${DOCKER_NETWORK}" >/dev/null 2>&1 || sudo docker network create "${DOCKER_NETWORK}"
+
+if ! sudo docker ps -a --format '{{.Names}}' | grep -qx "${REDIS_CONTAINER_NAME}"; then
+  sudo docker run -d \
+    --name "${REDIS_CONTAINER_NAME}" \
+    --network "${DOCKER_NETWORK}" \
+    --restart unless-stopped \
+    redis:7-alpine
+else
+  sudo docker network connect "${DOCKER_NETWORK}" "${REDIS_CONTAINER_NAME}" >/dev/null 2>&1 || true
+
+  if ! sudo docker ps --format '{{.Names}}' | grep -qx "${REDIS_CONTAINER_NAME}"; then
+    sudo docker start "${REDIS_CONTAINER_NAME}"
+  fi
+fi
+
+CONTAINER_ID=$(sudo docker ps -aqf "name=^/${CONTAINER_NAME}$")
+if [ -n "${CONTAINER_ID}" ]; then
+  echo "Stopping existing container: ${CONTAINER_ID}"
+  sudo docker stop "${CONTAINER_ID}"
+  sudo docker rm "${CONTAINER_ID}"
+else
+  echo "No existing container to stop."
+fi
+
+sudo docker pull "${IMAGE_NAME}"
+
+echo "Running the new container with image: ${IMAGE_NAME}"
+sudo docker run --name "${CONTAINER_NAME}" -d \
+  --network "${DOCKER_NETWORK}" \
+  -p 8080:8080 \
+  -e SPRING_PROFILES_ACTIVE=prod \
+  -e IDEAR_CRAWLER_ENABLED=false \
+  -e PROD_MYSQL_URL="${PROD_MYSQL_URL}" \
+  -e PROD_MYSQL_USER="${PROD_MYSQL_USER}" \
+  -e PROD_MYSQL_PASSWORD="${PROD_MYSQL_PASSWORD}" \
+  -e REDIS_HOST="${REDIS_CONTAINER_NAME}" \
+  -e REDIS_PORT=6379 \
+  -e JWT_KEY="${JWT_KEY}" \
+  -e FRONT_ORIGIN="${FRONT_ORIGIN}" \
+  -e S3_ACCESS_KEY="${S3_ACCESS_KEY}" \
+  -e S3_SECRET_KEY="${S3_SECRET_KEY}" \
+  -e KAKAO_CLIENT_ID="${KAKAO_CLIENT_ID}" \
+  -e KAKAO_CLIENT_SECRET="${KAKAO_CLIENT_SECRET}" \
+  -e KAKAO_REDIRECT_URI="${KAKAO_REDIRECT_URI}" \
+  -e NAVER_CLIENT_ID="${NAVER_CLIENT_ID}" \
+  -e NAVER_CLIENT_SECRET="${NAVER_CLIENT_SECRET}" \
+  -e NAVER_REDIRECT_URI="${NAVER_REDIRECT_URI}" \
+  -e GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID}" \
+  -e GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET}" \
+  -e GOOGLE_REDIRECT_URI="${GOOGLE_REDIRECT_URI}" \
+  -e BLOCKCHAIN_GATEWAY_URL="http://idear-chain:3000" \
+  -e SERVER_PRIVATE_KEY="${SERVER_PRIVATE_KEY}" \
+  -e SPRING_MAIL_USERNAME="${SPRING_MAIL_USERNAME}" \
+  -e SPRING_MAIL_PASSWORD="${SPRING_MAIL_PASSWORD}" \
+  "${IMAGE_NAME}"
+
+sudo docker system prune -f


### PR DESCRIPTION
### Desc

- GitHub Actions에서 ssh-action의 멀티라인 script 전달 과정에서 스크립트 파싱이 깨지는 문제로 인해 Docker 실행 시 잘못된 이미지명이 사용되는 이슈가 발생
- 배포 로직을 별도 deploy.sh 파일로 분리하고, scp-action으로 전송 후 EC2에서 직접 실행하도록 변경하여 스크립트 전달/개행 이슈를 제거