### PR TITLE
feat: 프로필 이미지 및 이메일 변경 로직 구현

### DIFF
--- a/.github/workflows/cd-api-workflow.yml
+++ b/.github/workflows/cd-api-workflow.yml
@@ -91,4 +91,5 @@ jobs:
             SPRING_MAIL_USERNAME='${{ secrets.SPRING_MAIL_USERNAME }}' \
             SPRING_MAIL_PASSWORD='${{ secrets.SPRING_MAIL_PASSWORD }}' \
             BLOCKCHAIN_CONTRACT_ADDRESS='${{ secrets.BLOCKCHAIN_CONTRACT_ADDRESS }}' \
+            USER_DEFAULT_PROFILE_IMAGE_URL='${{ secrets.USER_DEFAULT_PROFILE_IMAGE_URL }}' \
             bash /home/ubuntu/deploy/deploy.sh

--- a/src/main/java/com/idear/backend/global/config/UserProperties.java
+++ b/src/main/java/com/idear/backend/global/config/UserProperties.java
@@ -1,0 +1,39 @@
+package com.idear.backend.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "user")
+public class UserProperties {
+
+  private Profile profile = new Profile();
+  private Email email = new Email();
+
+  @Getter
+  @Setter
+  public static class Profile {
+    private String defaultImageUrl;
+    private long maxImageSize;
+    private List<String> allowedExtensions;
+  }
+
+  @Getter
+  @Setter
+  public static class Email {
+    private Verification verification = new Verification();
+
+    @Getter
+    @Setter
+    public static class Verification {
+      private long codeExpirationMinutes;
+      private long verifiedExpirationMinutes;
+    }
+  }
+}

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -24,6 +24,12 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저입니다."),
     USER_DELETED(HttpStatus.NOT_FOUND, "U002", "탈퇴 처리된 유저입니다."),
     USER_NOT_OWNER(HttpStatus.NOT_FOUND, "U003", "요청 대상 자원의 소유자가 아닙니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "U004", "이미 사용 중인 이메일입니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "U005", "유효하지 않은 인증 코드입니다."),
+    VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "U006", "인증 코드가 만료되었습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "U007", "이메일 인증이 완료되지 않았습니다."),
+    INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "U008", "유효하지 않은 이미지 파일입니다."),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "U009", "이미지 파일 크기가 너무 큽니다. (최대 5MB)"),
 
     // Idea
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드를 실패했습니다."),

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "U006", "인증 코드가 만료되었습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "U007", "이메일 인증이 완료되지 않았습니다."),
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "U008", "유효하지 않은 이미지 파일입니다."),
-    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "U009", "이미지 파일 크기가 너무 큽니다. (최대 5MB)"),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "U009", "이미지 파일 크기가 허용된 용량을 초과합니다."),
 
     // Idea
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드를 실패했습니다."),

--- a/src/main/java/com/idear/backend/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/idear/backend/global/security/oauth/service/CustomOAuth2UserService.java
@@ -6,7 +6,7 @@ import com.idear.backend.user.domain.User;
 import com.idear.backend.user.domain.UserRole;
 import com.idear.backend.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -21,6 +21,9 @@ import java.util.Map;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
+
+    @Value("${user.profile.default-image-url}")
+    private String defaultProfileImageUrl;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -50,7 +53,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         // DB에 유저 없으면 생성
         User user = userRepository.findByProviderInfo(providerInfo)
-                .orElseGet(() -> userRepository.save(User.of(name, email, providerInfo, UserRole.USER)));
+                .orElseGet(() -> {
+                    User newUser = User.of(name, email, providerInfo, UserRole.USER);
+                    // 모든 신규 사용자는 기본 프로필 이미지로 시작
+                    newUser.updateProfileImage(defaultProfileImageUrl);
+                    return userRepository.save(newUser);
+                });
 
         UserInfo userInfo = UserInfo.builder()
                 .id(user.getUserId())

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -157,11 +157,6 @@ public class UserService {
         user.updateProfileImage(defaultImageUrl);
     }
 
-    @Transactional
-    public void updateProfileImage(User user, String profileImageUrl) {
-        user.updateProfileImage(profileImageUrl);
-    }
-
     // 헬퍼 메서드
     private String generateVerificationCode() {
         Random random = new Random();

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -1,15 +1,35 @@
 package com.idear.backend.user.application.service;
 
+import com.idear.backend.email.service.EmailService;
+import com.idear.backend.global.config.UserProperties;
+import com.idear.backend.global.exception.CustomException;
+import com.idear.backend.global.exception.ErrorCode;
+import com.idear.backend.idea.application.FileStorageService;
 import com.idear.backend.user.domain.User;
 import com.idear.backend.user.dto.response.UserInfoResponse;
+import com.idear.backend.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+    private final FileStorageService fileStorageService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final UserProperties userProperties;
+
+    private static final String EMAIL_VERIFICATION_PREFIX = "email:verification:";
+    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
 
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(User user) {
@@ -29,5 +49,169 @@ public class UserService {
     @Transactional
     public void deleteUser(User user) {
         user.deleteUser();
+    }
+
+    // 이메일 인증 메서드
+    public void sendEmailVerificationCode(String email) {
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(email)) {
+            throw CustomException.of(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        // 6자리 인증 코드 생성
+        String code = generateVerificationCode();
+
+        // Redis에 설정된 만료 시간으로 저장
+        String key = EMAIL_VERIFICATION_PREFIX + email;
+        long expiration = userProperties.getEmail().getVerification().getCodeExpirationMinutes();
+        redisTemplate.opsForValue().set(key, code, expiration, TimeUnit.MINUTES);
+
+        // 이메일 전송
+        emailService.sendEmail(email, "[iDear] 이메일 인증 코드",
+                "인증 코드: " + code + "\n\n이 코드는 5분간 유효합니다.");
+    }
+
+    public void verifyEmailCode(String email, String code) {
+        String key = EMAIL_VERIFICATION_PREFIX + email;
+        String storedCode = (String) redisTemplate.opsForValue().get(key);
+
+        if (storedCode == null) {
+            throw CustomException.of(ErrorCode.VERIFICATION_CODE_EXPIRED);
+        }
+
+        if (!storedCode.equals(code)) {
+            throw CustomException.of(ErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        // 인증 완료 표시
+        String verifiedKey = EMAIL_VERIFIED_PREFIX + email;
+        long expiration = userProperties.getEmail().getVerification().getVerifiedExpirationMinutes();
+        redisTemplate.opsForValue().set(verifiedKey, "true", expiration, TimeUnit.MINUTES);
+
+        // 인증 코드 삭제
+        redisTemplate.delete(key);
+    }
+
+    @Transactional
+    public void updateEmail(User user, String email, String code) {
+        // 이메일 인증 확인
+        String verifiedKey = EMAIL_VERIFIED_PREFIX + email;
+        String verified = (String) redisTemplate.opsForValue().get(verifiedKey);
+
+        if (verified == null || !verified.equals("true")) {
+            throw CustomException.of(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        // 이메일 중복 재확인
+        if (userRepository.existsByEmail(email)) {
+            throw CustomException.of(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        // 이메일 업데이트
+        user.updateEmail(email);
+
+        // Redis 데이터 정리
+        redisTemplate.delete(verifiedKey);
+    }
+
+    // 프로필 이미지 메서드
+    @Transactional
+    public String uploadProfileImage(User user, MultipartFile file) {
+        // 파일 유효성 검사
+        validateImageFile(file);
+
+        // 고유한 파일명 생성
+        String originalFilename = file.getOriginalFilename();
+        String extension = getFileExtension(originalFilename);
+        String fileName = UUID.randomUUID().toString() + "." + extension;
+
+        // 기존 프로필 이미지 삭제 (존재하는 경우)
+        if (user.getProfileImageUrl() != null) {
+            deleteOldProfileImage(user.getProfileImageUrl());
+        }
+
+        // S3에 업로드
+        try {
+            String profileImageUrl = fileStorageService.uploadFile(file, fileName, "profile-images");
+
+            // 사용자 엔티티 업데이트
+            user.updateProfileImage(profileImageUrl);
+
+            return profileImageUrl;
+        } catch (Exception e) {
+            throw CustomException.of(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+    }
+
+    @Transactional
+    public void deleteProfileImage(User user) {
+        if (user.getProfileImageUrl() == null) {
+            return;
+        }
+
+        // S3에서 삭제
+        deleteOldProfileImage(user.getProfileImageUrl());
+
+        // 기본 이미지로 변경
+        String defaultImageUrl = userProperties.getProfile().getDefaultImageUrl();
+        user.updateProfileImage(defaultImageUrl);
+    }
+
+    @Transactional
+    public void updateProfileImage(User user, String profileImageUrl) {
+        user.updateProfileImage(profileImageUrl);
+    }
+
+    // 헬퍼 메서드
+    private String generateVerificationCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw CustomException.of(ErrorCode.INVALID_IMAGE_FILE);
+        }
+
+        // 파일 크기 확인
+        if (file.getSize() > userProperties.getProfile().getMaxImageSize()) {
+            throw CustomException.of(ErrorCode.IMAGE_FILE_TOO_LARGE);
+        }
+
+        // 파일 확장자 확인
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            throw CustomException.of(ErrorCode.INVALID_IMAGE_FILE);
+        }
+
+        String extension = getFileExtension(originalFilename).toLowerCase();
+        if (!userProperties.getProfile().getAllowedExtensions().contains(extension)) {
+            throw CustomException.of(ErrorCode.INVALID_IMAGE_FILE);
+        }
+
+        // 콘텐츠 타입 확인
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw CustomException.of(ErrorCode.INVALID_IMAGE_FILE);
+        }
+    }
+
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf(".") + 1);
+    }
+
+    private void deleteOldProfileImage(String profileImageUrl) {
+        try {
+            // URL에서 파일명 추출
+            String[] urlParts = profileImageUrl.split("/");
+            String fileName = urlParts[urlParts.length - 1];
+            fileStorageService.deleteFile(fileName, "profile-images");
+        } catch (Exception e) {
+            // 에러 로그만 남기고 작업은 실패시키지 않음
+            // 기존 파일은 S3에 남지만 참조되지 않음
+        }
     }
 }

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -9,15 +9,18 @@ import com.idear.backend.user.domain.User;
 import com.idear.backend.user.dto.response.UserInfoResponse;
 import com.idear.backend.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Random;
+import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -27,6 +30,7 @@ public class UserService {
     private final FileStorageService fileStorageService;
     private final RedisTemplate<String, Object> redisTemplate;
     private final UserProperties userProperties;
+    private final SecureRandom secureRandom = new SecureRandom();
 
     private static final String EMAIL_VERIFICATION_PREFIX = "email:verification:";
     private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
@@ -68,7 +72,7 @@ public class UserService {
 
         // 이메일 전송
         emailService.sendEmail(email, "[iDear] 이메일 인증 코드",
-                "인증 코드: " + code + "\n\n이 코드는 5분간 유효합니다.");
+                String.format("인증 코드: %s\n\n이 코드는 %d분간 유효합니다.", code, expiration));
     }
 
     public void verifyEmailCode(String email, String code) {
@@ -93,7 +97,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateEmail(User user, String email, String code) {
+    public void updateEmail(User user, String email) {
         // 이메일 인증 확인
         String verifiedKey = EMAIL_VERIFIED_PREFIX + email;
         String verified = (String) redisTemplate.opsForValue().get(verifiedKey);
@@ -138,7 +142,7 @@ public class UserService {
             user.updateProfileImage(profileImageUrl);
 
             return profileImageUrl;
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw CustomException.of(ErrorCode.FILE_UPLOAD_ERROR);
         }
     }
@@ -159,8 +163,7 @@ public class UserService {
 
     // 헬퍼 메서드
     private String generateVerificationCode() {
-        Random random = new Random();
-        return String.format("%06d", random.nextInt(1000000));
+        return String.format("%06d", secureRandom.nextInt(1000000));
     }
 
     private void validateImageFile(MultipartFile file) {
@@ -205,8 +208,8 @@ public class UserService {
             String fileName = urlParts[urlParts.length - 1];
             fileStorageService.deleteFile(fileName, "profile-images");
         } catch (Exception e) {
-            // 에러 로그만 남기고 작업은 실패시키지 않음
-            // 기존 파일은 S3에 남지만 참조되지 않음
+            // 에러 로그를 남기고 작업은 실패시키지 않음
+            log.error("Failed to delete old profile image: {}", profileImageUrl, e);
         }
     }
 }

--- a/src/main/java/com/idear/backend/user/controller/UserController.java
+++ b/src/main/java/com/idear/backend/user/controller/UserController.java
@@ -98,7 +98,7 @@ public class UserController {
 	public ResponseEntity<ApiResponse<Void>> updateEmail(
 			@Parameter(hidden = true) @ValidatedUser User user,
 			@Valid @RequestBody UpdateEmailRequest request) {
-		userService.updateEmail(user, request.getEmail(), request.getCode());
+		userService.updateEmail(user, request.getEmail());
 		return ResponseEntity.ok(ApiResponse.success());
 	}
 

--- a/src/main/java/com/idear/backend/user/controller/UserController.java
+++ b/src/main/java/com/idear/backend/user/controller/UserController.java
@@ -5,14 +5,17 @@ import com.idear.backend.global.annotation.ValidatedUser;
 import com.idear.backend.user.application.service.UserService;
 import com.idear.backend.user.domain.User;
 import com.idear.backend.user.dto.request.RegisterPublicKeyRequest;
+import com.idear.backend.user.dto.request.SendEmailVerificationRequest;
+import com.idear.backend.user.dto.request.UpdateEmailRequest;
 import com.idear.backend.user.dto.request.UpdateNameRequest;
+import com.idear.backend.user.dto.request.VerifyEmailCodeRequest;
+import com.idear.backend.user.dto.response.ProfileImageResponse;
 import com.idear.backend.user.dto.response.UserInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -71,6 +74,48 @@ public class UserController {
 		@Parameter(hidden = true) @ValidatedUser User user
 	) {
 		userService.deleteUser(user);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@Operation(summary = "이메일 인증 코드 전송", description = "이메일 변경을 위한 인증 코드를 전송합니다.")
+	@PostMapping("/email/verification")
+	public ResponseEntity<ApiResponse<Void>> sendEmailVerificationCode(
+			@Valid @RequestBody SendEmailVerificationRequest request) {
+		userService.sendEmailVerificationCode(request.getEmail());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@Operation(summary = "이메일 인증 코드 검증", description = "전송된 인증 코드를 검증합니다.")
+	@PostMapping("/email/verification/verify")
+	public ResponseEntity<ApiResponse<Void>> verifyEmailCode(
+			@Valid @RequestBody VerifyEmailCodeRequest request) {
+		userService.verifyEmailCode(request.getEmail(), request.getCode());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@Operation(summary = "이메일 변경", description = "인증된 이메일로 변경합니다.")
+	@PatchMapping("/email")
+	public ResponseEntity<ApiResponse<Void>> updateEmail(
+			@Parameter(hidden = true) @ValidatedUser User user,
+			@Valid @RequestBody UpdateEmailRequest request) {
+		userService.updateEmail(user, request.getEmail(), request.getCode());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@Operation(summary = "프로필 이미지 업로드", description = "프로필 이미지를 업로드합니다.")
+	@PostMapping(value = "/profile-image", consumes = "multipart/form-data")
+	public ResponseEntity<ApiResponse<ProfileImageResponse>> uploadProfileImage(
+			@Parameter(hidden = true) @ValidatedUser User user,
+			@RequestParam("file") org.springframework.web.multipart.MultipartFile file) {
+		String profileImageUrl = userService.uploadProfileImage(user, file);
+		return ResponseEntity.ok(ApiResponse.success(ProfileImageResponse.of(profileImageUrl)));
+	}
+
+	@Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 삭제하고 기본 이미지로 변경합니다.")
+	@DeleteMapping("/profile-image")
+	public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
+			@Parameter(hidden = true) @ValidatedUser User user) {
+		userService.deleteProfileImage(user);
 		return ResponseEntity.ok(ApiResponse.success());
 	}
 }

--- a/src/main/java/com/idear/backend/user/domain/User.java
+++ b/src/main/java/com/idear/backend/user/domain/User.java
@@ -40,6 +40,8 @@ public class User {
     @Column(length = 500)
     private String publicKey;
 
+    private String profileImageUrl;
+
     private LocalDateTime deletedAt;
 
     public static User of(String name, String email, String providerInfo, UserRole role){
@@ -57,6 +59,14 @@ public class User {
 
     public void updateUsername(String name){
         this.name = name;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 
     public void registerPublicKey(String publicKey) {

--- a/src/main/java/com/idear/backend/user/dto/request/SendEmailVerificationRequest.java
+++ b/src/main/java/com/idear/backend/user/dto/request/SendEmailVerificationRequest.java
@@ -1,0 +1,12 @@
+package com.idear.backend.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SendEmailVerificationRequest {
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "올바른 이메일 형식이 아닙니다.")
+  private String email;
+}

--- a/src/main/java/com/idear/backend/user/dto/request/UpdateEmailRequest.java
+++ b/src/main/java/com/idear/backend/user/dto/request/UpdateEmailRequest.java
@@ -1,0 +1,15 @@
+package com.idear.backend.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateEmailRequest {
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "올바른 이메일 형식이 아닙니다.")
+  private String email;
+
+  @NotBlank(message = "인증 코드는 필수입니다.")
+  private String code;
+}

--- a/src/main/java/com/idear/backend/user/dto/request/UpdateEmailRequest.java
+++ b/src/main/java/com/idear/backend/user/dto/request/UpdateEmailRequest.java
@@ -9,7 +9,4 @@ public class UpdateEmailRequest {
   @NotBlank(message = "이메일은 필수입니다.")
   @Email(message = "올바른 이메일 형식이 아닙니다.")
   private String email;
-
-  @NotBlank(message = "인증 코드는 필수입니다.")
-  private String code;
 }

--- a/src/main/java/com/idear/backend/user/dto/request/VerifyEmailCodeRequest.java
+++ b/src/main/java/com/idear/backend/user/dto/request/VerifyEmailCodeRequest.java
@@ -1,0 +1,15 @@
+package com.idear.backend.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class VerifyEmailCodeRequest {
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "올바른 이메일 형식이 아닙니다.")
+  private String email;
+
+  @NotBlank(message = "인증 코드는 필수입니다.")
+  private String code;
+}

--- a/src/main/java/com/idear/backend/user/dto/response/ProfileImageResponse.java
+++ b/src/main/java/com/idear/backend/user/dto/response/ProfileImageResponse.java
@@ -1,0 +1,14 @@
+package com.idear.backend.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileImageResponse {
+  private String profileImageUrl;
+
+  public static ProfileImageResponse of(String profileImageUrl) {
+    return new ProfileImageResponse(profileImageUrl);
+  }
+}

--- a/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
@@ -11,6 +11,7 @@ public class UserInfoResponse {
 	private String email;
 	private String provider;
 	private String publicKey;
+	private String profileImageUrl;
 
 	public static UserInfoResponse from(User user) {
 		return UserInfoResponse.builder()
@@ -18,6 +19,7 @@ public class UserInfoResponse {
 				.email(user.getEmail())
 				.provider(user.getProvider())
 				.publicKey(user.getPublicKey())
+				.profileImageUrl(user.getProfileImageUrl())
 				.build();
 	}
 }

--- a/src/main/java/com/idear/backend/user/infrastructure/repository/UserRepository.java
+++ b/src/main/java/com/idear/backend/user/infrastructure/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderInfo(String providerInfo);
 
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,16 @@ blockchain:
   contract:
     address: ${BLOCKCHAIN_CONTRACT_ADDRESS}
 
+user:
+  profile:
+    default-image-url: ${USER_DEFAULT_PROFILE_IMAGE_URL}
+    max-image-size: ${USER_PROFILE_MAX_IMAGE_SIZE:5242880} # 5MB in bytes
+    allowed-extensions: ${USER_PROFILE_ALLOWED_EXTENSIONS:jpg,jpeg,png,gif,webp}
+  email:
+    verification:
+      code-expiration-minutes: ${EMAIL_VERIFICATION_CODE_EXPIRATION:5}
+      verified-expiration-minutes: ${EMAIL_VERIFIED_EXPIRATION:10}
+
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ blockchain:
 
 user:
   profile:
-    default-image-url: ${USER_DEFAULT_PROFILE_IMAGE_URL}
+    default-image-url: ${USER_DEFAULT_PROFILE_IMAGE_URL:https://idear-file.s3.ap-northeast-2.amazonaws.com/profile-images/default-image.png}
     max-image-size: ${USER_PROFILE_MAX_IMAGE_SIZE:5242880} # 5MB in bytes
     allowed-extensions: ${USER_PROFILE_ALLOWED_EXTENSIONS:jpg,jpeg,png,gif,webp}
   email:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -49,6 +49,19 @@ spring:
       username: idear.developer@gmail.com
       password: testpwd
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
+  task:
+    scheduling:
+      enabled: false
+
+idear:
+  crawler:
+    enabled: false
+
 secret:
   jwt:
     key: testjwtsecretkeytestjwtsecretkeytestjwtsecretkeytestjwtsecretkey
@@ -73,3 +86,13 @@ blockchain:
     private-key: "0x0000000000000000000000000000000000000000000000000000000000000001"
   contract:
     address: "0x0000000000000000000000000000000000000000"
+
+user:
+  profile:
+    default-image-url: https://idear-file.s3.ap-northeast-2.amazonaws.com/profile-images/default-image.png
+    max-image-size: 5242880
+    allowed-extensions: jpg,jpeg,png,gif,webp
+  email:
+    verification:
+      code-expiration-minutes: 5
+      verified-expiration-minutes: 10


### PR DESCRIPTION
### 연관된 이슈

> #49 

### 작업 내용

1. 사용자 프로필 이미지 관리 기능
- S3 연동 구현: S3FileStorageService를 통해 프로필 이미지를 AWS S3에 업로드 및 관리하는 로직을 구현
- 기본 이미지 설정: 프로필 이미지가 없는 사용자를 위한 기본 이미지 URL 설정을 
application.yml에 추가
- 이미지 수정/삭제: 기존 이미지를 교체하거나 기본 이미지로 초기화하는 기능을 추가

2. 이메일 변경 로직 구현
- 인증 시스템 도입: 이메일 인증 코드 검증 및 기존 확인 단계를 추가
- 관련 DTO 추가: 이메일 중복 확인, 인증 코드 검증, 변경 요청을 위한 전용 DTO를 구현

3. API 엔드포인트 확장
- UserController에 프로필 이미지 업로드/변경 및 이메일 인증 관련 REST API 구현
- 회원 정보 조회 시 프로필 이미지 정보를 함께 반환

4. 인프라 및 테스트 환경 정비
- CI 빌드 오류 해결: 누락된 환경 변수 더미 값을 추가하여 CI/CD 파이프라인의 테스트 실패 문제를 해결
- 설정 최신화: 프로필 이미지 크기 제한, 허용 확장자 등 상세 정책을 가변적으로 관리할 수 있도록 UserProperties를 구성

