### PR TITLE
feat: 아이디어 증명서 구성 정보 조회 기능 구현 및 응답 데이터 정리

### DIFF
--- a/src/main/java/com/idear/backend/blockchain/application/BlockchainService.java
+++ b/src/main/java/com/idear/backend/blockchain/application/BlockchainService.java
@@ -89,10 +89,13 @@ public class BlockchainService {
 		Integer blockNumber = request.getSuccessData().getBlockNumber();
 		Long registeredAt = request.getSuccessData().getRegisteredAt();
 
-		log.info("Processing SUCCESS: ideaFileId={}, txHash={}, registeredAt={}, blockNumber={}",
-				ideaFile.getIdeaFileId(), txHash, registeredAt, request.getSuccessData().getBlockNumber());
+		// 블록체인 서버는 초 단위로 전송하기에 밀리초 변환
+		Long registeredAtMillis = registeredAt * 1000;
 
-		ideaFile.registrationSucceed(txHash, blockNumber, registeredAt);
+		log.info("Processing SUCCESS: ideaFileId={}, txHash={}, registeredAt={}, blockNumber={}",
+				ideaFile.getIdeaFileId(), txHash, registeredAtMillis, request.getSuccessData().getBlockNumber());
+
+		ideaFile.registrationSucceed(txHash, blockNumber, registeredAtMillis);
 
 		Idea idea = ideaRepository.findIdeaByFile(ideaFile)
 				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));

--- a/src/main/java/com/idear/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/idear/backend/global/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     CERTIFICATE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CT001", "증명서 생성에 실패했습니다."),
     CERTIFICATE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CT002", "증명서 업로드에 실패했습니다."),
     FILE_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "CT003", "블록체인 등록이 완료되지 않은 파일입니다."),
+    LATEST_VERSION_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "CT004", "최신 버전의 파일에 대해 블록체인 등록이 완료되지 않았습니다."),
 
     // Inquiry
     NOT_FOUND_INQUIRY(HttpStatus.NOT_FOUND, "Q001", "존재하지 않는 문의입니다."),

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -22,6 +22,7 @@ import com.idear.backend.idea.util.HashUtil;
 import com.idear.backend.idea.util.ServerSignatureService;
 import com.idear.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,13 +30,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class IdeaService {
+
+	private static final String BLOCKCHAIN_NETWORK = "Sepolia";
 
 	private final IdeaRepository ideaRepository;
 	private final IdeaVersionRepository ideaVersionRepository;
@@ -46,6 +49,9 @@ public class IdeaService {
 	private final ContestRepository contestRepository;
 	private final HashUtil hashUtil;
 	private final ServerSignatureService serverSignatureService;
+
+	@Value("${blockchain.contract.address}")
+	private String contractAddress;
 
 	@Transactional
 	public IdeaRegistrationInitResponse initIdeaRegistration(
@@ -61,7 +67,7 @@ public class IdeaService {
 		}
 
 		LocalDateTime requestedAt = LocalDateTime.now();
-		Long requestTimestamp = requestedAt.toEpochSecond(ZoneOffset.UTC);
+		Long requestTimestamp = Instant.now().toEpochMilli();
 
 		Idea idea = Idea.register(
 				user,
@@ -181,7 +187,7 @@ public class IdeaService {
 		IdeaVersion targetVersion;
 		List<FileHashInfo> fileHashInfoList = new ArrayList<>();
 		LocalDateTime updatedAt = LocalDateTime.now();
-		Long timestamp = updatedAt.toEpochSecond(ZoneOffset.UTC);
+		Long timestamp = Instant.now().toEpochMilli();
 
 		if (hasFileChanges) {
 			Integer maxVersionNumber = ideaVersionRepository
@@ -264,6 +270,38 @@ public class IdeaService {
 		}
 
 		ideaRepository.delete(idea);
+	}
+
+	@Transactional(readOnly = true)
+	public IdeaCertificateResponse getCertificateData(User user, Long ideaId) {
+		Idea idea = ideaRepository.findById(ideaId)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
+
+		if (!idea.getUser().getUserId().equals(user.getUserId())) {
+			throw CustomException.of(ErrorCode.ACCESS_DENIED);
+		}
+
+		IdeaVersion latestVersion = ideaVersionRepository
+				.findTopByIdeaOrderByVersionNumberDesc(idea)
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_VERSION_NOT_FOUND));
+
+		IdeaFile ideaFile = latestVersion.getFiles().stream()
+				.findFirst()
+				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_FILE_NOT_FOUND));
+
+		if (ideaFile.getRegisterStatus() != IdeaFile.RegisterStatus.REGISTERED) {
+			throw CustomException.of(ErrorCode.LATEST_VERSION_NOT_REGISTERED);
+		}
+
+		String ideaTitle = latestVersion.getTitle();
+
+		return IdeaCertificateResponse.of(
+				user,
+				ideaFile,
+				ideaTitle,
+				BLOCKCHAIN_NETWORK,
+				contractAddress
+		);
 	}
 
 	private boolean hasNonEmptyFiles(List<MultipartFile> files) {

--- a/src/main/java/com/idear/backend/idea/application/IdeaService.java
+++ b/src/main/java/com/idear/backend/idea/application/IdeaService.java
@@ -255,9 +255,12 @@ public class IdeaService {
 		}
 
 		List<IdeaVersion> versions = ideaVersionRepository.findAllByIdeaOrderByVersionNumberDesc(idea);
-		String latestCertificateUrl = getLatestCertificateUrl(versions);
+		IdeaFile latestFile = getLatestFile(versions);
 
-		return IdeaWithVersionsResponse.of(idea, versions, latestCertificateUrl);
+		String latestCertificateUrl = getLatestCertificateUrl(latestFile);
+		Boolean latestVersionRegistered = checkLatestVersionRegistered(latestFile);
+
+		return IdeaWithVersionsResponse.of(idea, versions, latestCertificateUrl, latestVersionRegistered);
 	}
 
 	@Transactional
@@ -410,16 +413,22 @@ public class IdeaService {
 		}
 	}
 
-	private String getLatestCertificateUrl(List<IdeaVersion> versions) {
+	private IdeaFile getLatestFile(List<IdeaVersion> versions) {
 		if (versions.isEmpty()) {
 			return null;
 		}
 
 		IdeaVersion latestVersion = versions.getFirst();
 		return latestVersion.getFiles().stream()
-				.map(IdeaFile::getCertificateUrl)
-				.filter(Objects::nonNull)
 				.findFirst()
 				.orElse(null);
+	}
+
+	private String getLatestCertificateUrl(IdeaFile latestFile) {
+		return latestFile != null ? latestFile.getCertificateUrl() : null;
+	}
+
+	private Boolean checkLatestVersionRegistered(IdeaFile latestFile) {
+		return latestFile != null && latestFile.getRegisterStatus() == IdeaFile.RegisterStatus.REGISTERED;
 	}
 }

--- a/src/main/java/com/idear/backend/idea/controller/IdeaController.java
+++ b/src/main/java/com/idear/backend/idea/controller/IdeaController.java
@@ -128,4 +128,18 @@ public class IdeaController {
 		ideaService.deleteIdea(user, ideaId);
 		return ResponseEntity.ok(ApiResponse.success());
 	}
+
+	@Operation(
+		summary = "증명서 데이터 조회",
+		description = "아이디어의 최신 버전에 대한 증명서 발급 데이터를 조회합니다. 최신 버전의 파일이 블록체인에 등록(REGISTERED)되어 있어야 합니다."
+	)
+	@GetMapping("/{ideaId}/certificate")
+	public ResponseEntity<ApiResponse<IdeaCertificateResponse>> getCertificateData(
+		@Parameter(hidden = true) @ValidatedUser User user,
+		@Parameter(description = "아이디어 ID", required = true, example = "1")
+		@PathVariable("ideaId") Long ideaId
+	) {
+		IdeaCertificateResponse response = ideaService.getCertificateData(user, ideaId);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
 }

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaCertificateResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaCertificateResponse.java
@@ -1,0 +1,66 @@
+package com.idear.backend.idea.dto.response;
+
+import com.idear.backend.idea.domain.IdeaFile;
+import com.idear.backend.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class IdeaCertificateResponse {
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	private String submitter;
+	private String ideaTitle;
+	private String submissionDate;
+	private String documentHash;
+
+	private String network;
+	private String contractAddress;
+	private String commit;
+	private String txHash;
+	private Integer blockNumber;
+	private String onChainTimestamp;
+
+	private String issuedAt;
+	private String documentNumber;
+
+	public static IdeaCertificateResponse of(
+			User user,
+			IdeaFile ideaFile,
+			String ideaTitle,
+			String network,
+			String contractAddress
+	) {
+		return IdeaCertificateResponse.builder()
+				.submitter(user.getName())
+				.submissionDate(formatTimestamp(ideaFile.getRequestedTimestamp()))
+				.ideaTitle(ideaTitle)
+				.documentHash(ideaFile.getFileHash())
+				.network(network)
+				.contractAddress(contractAddress)
+				.commit(ideaFile.getCommit())
+				.txHash(ideaFile.getTxHash())
+				.blockNumber(ideaFile.getBlockNumber())
+				.onChainTimestamp(formatTimestamp(ideaFile.getRegisteredTimestamp()))
+				.issuedAt(LocalDateTime.now(SEOUL_ZONE).format(DATE_TIME_FORMATTER))
+				.documentNumber(String.valueOf(ideaFile.getIdeaFileId()))
+				.build();
+	}
+
+	private static String formatTimestamp(Long timestamp) {
+		if (timestamp == null) {
+			return null;
+		}
+		return LocalDateTime.ofInstant(
+				Instant.ofEpochMilli(timestamp),
+				SEOUL_ZONE
+		).format(DATE_TIME_FORMATTER);
+	}
+}

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaFileInfo.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaFileInfo.java
@@ -11,18 +11,12 @@ public class IdeaFileInfo {
 	private Long ideaFileId;
 	private String fileName;
 	private String filePath;
-	private IdeaFile.RegisterStatus status;
-	private String txHash;
-	private String certificateUrl;
 
 	public static IdeaFileInfo of(IdeaFile ideaFile) {
 		return IdeaFileInfo.builder()
 				.ideaFileId(ideaFile.getIdeaFileId())
 				.fileName(ideaFile.getOriginalFileName())
 				.filePath(ideaFile.getFilePath())
-				.status(ideaFile.getRegisterStatus())
-				.txHash(ideaFile.getTxHash())
-				.certificateUrl(ideaFile.getCertificateUrl())
 				.build();
 	}
 }

--- a/src/main/java/com/idear/backend/idea/dto/response/IdeaWithVersionsResponse.java
+++ b/src/main/java/com/idear/backend/idea/dto/response/IdeaWithVersionsResponse.java
@@ -18,9 +18,10 @@ public class IdeaWithVersionsResponse {
 	private String contestTitle;
 	private LocalDateTime requestedAt;
 	private String latestCertificateUrl;
+	private Boolean latestVersionRegistered;
 	private List<VersionDetailInfo> versions;
 
-	public static IdeaWithVersionsResponse of(Idea idea, List<IdeaVersion> versions, String latestCertificateUrl) {
+	public static IdeaWithVersionsResponse of(Idea idea, List<IdeaVersion> versions, String latestCertificateUrl, Boolean latestVersionRegistered) {
 		List<VersionDetailInfo> versionInfos = versions.stream()
 				.map(VersionDetailInfo::of)
 				.collect(Collectors.toList());
@@ -38,6 +39,7 @@ public class IdeaWithVersionsResponse {
 				.contestTitle(contestTitle)
 				.requestedAt(idea.getRequestedAt())
 				.latestCertificateUrl(latestCertificateUrl)
+				.latestVersionRegistered(latestVersionRegistered)
 				.versions(versionInfos)
 				.build();
 	}


### PR DESCRIPTION
### 작업 내용

- 아이디어 증명서 정보 조회 API 구현
- 응답 데이터 시간대 표기 방식 통일
- 아이디어 상세 조회 시 최신 아이디어 버전에 해당하는 파일 체인 등록 여부 확인이 가능한 Flag 변수 추가
- IdeaFileInfo에서 불필요한 status, txHash, certificateUrl 삭제