### PR TITLE
feat: 푸시 알람/이메일 수신여부 설정 및 제어 기능 구현

### DIFF
--- a/src/main/java/com/idear/backend/blockchain/application/BlockchainService.java
+++ b/src/main/java/com/idear/backend/blockchain/application/BlockchainService.java
@@ -30,6 +30,13 @@ import java.util.Map;
 @Slf4j
 public class BlockchainService {
 
+	private static final String ALERT_MESSAGE_SUCCESS = "아이디어 파일이 등록되었습니다. 내용이 맞는지 확인해주세요.";
+	private static final String ALERT_MESSAGE_FAILURE = "아이디어 파일 등록이 실패하였습니다. 상세 내역을 확인해주세요.";
+
+	private static final String REGISTRATION_STATUS_SUCCESS = "성공";
+	private static final String REGISTRATION_STATUS_FAILURE = "실패";
+	private static final String EMAIL_SUBJECT = "iDear - 블록체인 등록 결과";
+
 	@Value("${blockchain.gateway.url}")
 	private String blockchainGatewayUrl;
 
@@ -109,16 +116,8 @@ public class BlockchainService {
 			log.error("Certificate generation failed for fileId={}", ideaFile.getIdeaFileId(), e);
 		}
 
-		alertService.createRegistrationAlert(
-				"아이디어 파일이 등록되었습니다. 내용이 맞는지 확인해주세요.",
-				user,
-				idea.getIdeaId(),
-				ideaFile
-		);
-		Map<String, Object> variables = new HashMap<>();
-		variables.put("userName", user.getName());
-		variables.put("registrationStatus", "성공");
-		emailService.sendEmailWithTemplate(user.getEmail(), "iDear - 블록체인 등록 결과", "blockchain-registration", variables);
+		sendAlertIfEnabled(user, idea.getIdeaId(), ideaFile, ALERT_MESSAGE_SUCCESS);
+		sendRegistrationEmailIfEnabled(user, REGISTRATION_STATUS_SUCCESS, null);
 	}
 
 	private void handleRegistrationFailure(RegistrationResultRequest request, IdeaFile ideaFile){
@@ -139,18 +138,26 @@ public class BlockchainService {
 				.orElseThrow(() -> CustomException.of(ErrorCode.IDEA_NOT_FOUND));
 		User user = idea.getUser();
 
-		alertService.createRegistrationAlert(
-				"아이디어 파일 등록이 실패하였습니다. 상세 내역을 확인해주세요.",
-				user,
-				idea.getIdeaId(),
-				ideaFile
-		);
+		sendAlertIfEnabled(user, idea.getIdeaId(), ideaFile, ALERT_MESSAGE_FAILURE);
+		sendRegistrationEmailIfEnabled(user, REGISTRATION_STATUS_FAILURE, reason.toString());
+	}
 
-		Map<String, Object> variables = new HashMap<>();
-		variables.put("userName", user.getName());
-		variables.put("registrationStatus", "실패");
-		variables.put("failureReason", reason.toString());
-		emailService.sendEmailWithTemplate(user.getEmail(), "iDear - 블록체인 등록 결과", "blockchain-registration", variables);
+	private void sendAlertIfEnabled(User user, Long ideaId, IdeaFile ideaFile, String message) {
+		if (Boolean.TRUE.equals(user.getPushEnabled())) {
+			alertService.createRegistrationAlert(message, user, ideaId, ideaFile);
+		}
+	}
+
+	private void sendRegistrationEmailIfEnabled(User user, String status, String failureReason) {
+		if (Boolean.TRUE.equals(user.getEmailEnabled())) {
+			Map<String, Object> variables = new HashMap<>();
+			variables.put("userName", user.getName());
+			variables.put("registrationStatus", status);
+			if (failureReason != null) {
+				variables.put("failureReason", failureReason);
+			}
+			emailService.sendEmailWithTemplate(user.getEmail(), EMAIL_SUBJECT, "blockchain-registration", variables);
+		}
 	}
 
 	private record CommitRegistrationRequest(

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -55,6 +55,11 @@ public class UserService {
         user.deleteUser();
     }
 
+    @Transactional
+    public void updateNotificationSettings(User user, Boolean pushEnabled, Boolean emailEnabled) {
+        user.updateNotificationSettings(pushEnabled, emailEnabled);
+    }
+
     // 이메일 인증 메서드
     public void sendEmailVerificationCode(String email) {
         // 이메일 중복 확인

--- a/src/main/java/com/idear/backend/user/controller/UserController.java
+++ b/src/main/java/com/idear/backend/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.idear.backend.user.dto.request.RegisterPublicKeyRequest;
 import com.idear.backend.user.dto.request.SendEmailVerificationRequest;
 import com.idear.backend.user.dto.request.UpdateEmailRequest;
 import com.idear.backend.user.dto.request.UpdateNameRequest;
+import com.idear.backend.user.dto.request.UpdateNotificationSettingsRequest;
 import com.idear.backend.user.dto.request.VerifyEmailCodeRequest;
 import com.idear.backend.user.dto.response.ProfileImageResponse;
 import com.idear.backend.user.dto.response.UserInfoResponse;
@@ -116,6 +117,15 @@ public class UserController {
 	public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
 			@Parameter(hidden = true) @ValidatedUser User user) {
 		userService.deleteProfileImage(user);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@Operation(summary = "알림 설정 변경", description = "푸시 알림 및 이메일 수신 설정을 변경합니다.")
+	@PatchMapping("/notification-settings")
+	public ResponseEntity<ApiResponse<Void>> updateNotificationSettings(
+			@Parameter(hidden = true) @ValidatedUser User user,
+			@RequestBody UpdateNotificationSettingsRequest request) {
+		userService.updateNotificationSettings(user, request.getPush(), request.getEmail());
 		return ResponseEntity.ok(ApiResponse.success());
 	}
 }

--- a/src/main/java/com/idear/backend/user/domain/User.java
+++ b/src/main/java/com/idear/backend/user/domain/User.java
@@ -42,6 +42,14 @@ public class User {
 
     private String profileImageUrl;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean pushEnabled = true;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean emailEnabled = true;
+
     private LocalDateTime deletedAt;
 
     public static User of(String name, String email, String providerInfo, UserRole role){
@@ -75,5 +83,14 @@ public class User {
 
     public void deleteUser(){
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void updateNotificationSettings(Boolean pushEnabled, Boolean emailEnabled) {
+        if (pushEnabled != null) {
+            this.pushEnabled = pushEnabled;
+        }
+        if (emailEnabled != null) {
+            this.emailEnabled = emailEnabled;
+        }
     }
 }

--- a/src/main/java/com/idear/backend/user/dto/request/UpdateNotificationSettingsRequest.java
+++ b/src/main/java/com/idear/backend/user/dto/request/UpdateNotificationSettingsRequest.java
@@ -1,0 +1,9 @@
+package com.idear.backend.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNotificationSettingsRequest {
+	private Boolean push;
+	private Boolean email;
+}

--- a/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
@@ -12,6 +12,8 @@ public class UserInfoResponse {
 	private String provider;
 	private String publicKey;
 	private String profileImageUrl;
+	private Boolean pushEnabled;
+	private Boolean emailEnabled;
 
 	public static UserInfoResponse from(User user) {
 		return UserInfoResponse.builder()
@@ -20,6 +22,8 @@ public class UserInfoResponse {
 				.provider(user.getProvider())
 				.publicKey(user.getPublicKey())
 				.profileImageUrl(user.getProfileImageUrl())
+				.pushEnabled(user.getPushEnabled())
+				.emailEnabled(user.getEmailEnabled())
 				.build();
 	}
 }


### PR DESCRIPTION
### 작업 내용

- User에 pushEnabled, emailEnabled 필드 추가
- 수신여부 설정 API 구현 (`PATCH /api/users/notification-settings`)
- UserInfoResponse에 pushEnabled, emailEnabled 추가
- 블록체인 웹훅 처리시 수신여부에 따라 알림/이메일 생성 제어