### PR TITLE
fix: 유저 기본 프로필 이미지 설정 로직 보강

### DIFF
--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -147,20 +147,6 @@ public class UserService {
         }
     }
 
-    @Transactional
-    public void deleteProfileImage(User user) {
-        if (user.getProfileImageUrl() == null) {
-            return;
-        }
-
-        // S3에서 삭제
-        deleteOldProfileImage(user.getProfileImageUrl());
-
-        // 기본 이미지로 변경
-        String defaultImageUrl = userProperties.getProfile().getDefaultImageUrl();
-        user.updateProfileImage(defaultImageUrl);
-    }
-
     // 헬퍼 메서드
     private String generateVerificationCode() {
         return String.format("%06d", secureRandom.nextInt(1000000));

--- a/src/main/java/com/idear/backend/user/application/service/UserService.java
+++ b/src/main/java/com/idear/backend/user/application/service/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(User user) {
-        return UserInfoResponse.from(user);
+        return UserInfoResponse.from(user, userProperties.getProfile().getDefaultImageUrl());
     }
 
     @Transactional

--- a/src/main/java/com/idear/backend/user/controller/UserController.java
+++ b/src/main/java/com/idear/backend/user/controller/UserController.java
@@ -110,12 +110,4 @@ public class UserController {
 		String profileImageUrl = userService.uploadProfileImage(user, file);
 		return ResponseEntity.ok(ApiResponse.success(ProfileImageResponse.of(profileImageUrl)));
 	}
-
-	@Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 삭제하고 기본 이미지로 변경합니다.")
-	@DeleteMapping("/profile-image")
-	public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
-			@Parameter(hidden = true) @ValidatedUser User user) {
-		userService.deleteProfileImage(user);
-		return ResponseEntity.ok(ApiResponse.success());
-	}
 }

--- a/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/idear/backend/user/dto/response/UserInfoResponse.java
@@ -13,13 +13,18 @@ public class UserInfoResponse {
 	private String publicKey;
 	private String profileImageUrl;
 
-	public static UserInfoResponse from(User user) {
+	public static UserInfoResponse from(User user, String defaultImageUrl) {
+		String profileImageUrl = user.getProfileImageUrl();
+		if (profileImageUrl == null || profileImageUrl.isBlank()) {
+			profileImageUrl = defaultImageUrl;
+		}
+
 		return UserInfoResponse.builder()
 				.name(user.getName())
 				.email(user.getEmail())
 				.provider(user.getProvider())
 				.publicKey(user.getPublicKey())
-				.profileImageUrl(user.getProfileImageUrl())
+				.profileImageUrl(profileImageUrl)
 				.build();
 	}
 }


### PR DESCRIPTION
### 연관된 이슈

> #49 

### 작업 내용
- 회원가입 시 설정파일의 기본 이미지 URL을 명시적으로 DB에 저장하도록 수정
- 유저 정보 조회 응답 시 DB 값이 비어있을 경우를 대비한 2중 안전장치(Fallback) 추가
- 설정 파일의 기본 이미지 경로가 실제 서비스에 안정적으로 반영되도록 개선
- 사용하지 않는 '프로필 이미지 삭제' 관련 메서드 삭제
